### PR TITLE
Add an Elasticsearch store interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,58 +7,41 @@ Elasticsearch configuration using [microcosm](https://github.com/globality-corp/
 
 ## Usage
 
-    from microcosm.api import create_object_graph
+ - Provides a `microcosm` compatible `Elasticsearch` client
+    -  Supports signed requests for AWS Elasticsearch using AWS4Auth
+    -  Supports IAM Role-based credentials based on instance metadata when running on EC2
+    -  Provides proper unicode support for Python 2.x / 3.x codebases
 
-    graph = create_object_graph(name="foo")
-    graph.use("elasticsearch_client")
-
-    # create an index
-    graph.elasticsearch_client.indices.create(
-        index="my-index",
-        body=dict(
-            settings=dict(
-                "number_of_shards": 1,
-                "number_of_replicas": 0,
-            )
-        )
-    )
-
-    # bulk index documents
-    from elasticsearch.helpers import streaming_bulk
-    docs_generator = some_generator_expression_yielding_dicts
-    for ok, result in streaming_bulk(
-        graph.elasticsearch_client,
-        docs_generator,
-        index="my-index",
-        doc_type="my-doc-type",
-        chunk_size=100,
-        refresh=True,
-        ):
-        if not ok:
-            raise RuntimeError("Bulk indexing failed for batch!")
+ - Includes an implementation of a persistence `Store` using Elasticsarch
 
 
-## Convention
+## Testing
 
- - Support for signed requests for AWS Elasticsearch using AWS4Auth
- - Support for IAM Role-based credentials based on instance metadata when running on EC2
- - Proper unicode support for Python 2.x / 3.x codebases
+Unit tests depend on a running instance of Elasticsearch:
+
+ 1. Bring up the ES with `docker-compose`:
+
+         docker-compose up -d
+
+ 2. Run tests:
+
+         nosetests
 
 
 ## Configuration
 
 When using with an AWS Elasticsearch instance, use:
 
-    config.elasticsearch_client.use_aws4auth = True
+    config.elasticsearch_client.use_aws4auth = 'true'
     config.elasticsearch_client.aws_access_key_id = 'aws-access-key-id'  # Will try to read from AWS_ACCESS_KEY_ID env var. by default
     config.elasticsearch_client.aws_secret_access_key = 'aws-secret-access-key'  # Will try to read from AWS_SECRET_ACCESS_KEY env var. by default
     config.elasticsearch_client.aws_region = 'aws-region'  # Will try to read from AWS_REGION env var. by default
 
 When configuring for running on an EC2 instance and use the instance's IAM role-provided AWS credentials:
 
-    config.elasticsearch_client.use_aws4auth = True
-    config.elasticsearch_client.use_aws_instance_metadata = True
+    config.elasticsearch_client.use_aws4auth = 'true'
+    config.elasticsearch_client.use_aws_instance_metadata = 'true'
 
 For proper Unicode support on Python 2.x, use:
 
-    config.elasticsearch_client.use_python2_serializer = True
+    config.elasticsearch_client.use_python2_serializer = 'true'

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ database:
 
 test:
   override:
-     - tox
+    - tox
     # stop test ES database
     - docker-compose stop
 

--- a/circle.yml
+++ b/circle.yml
@@ -27,15 +27,14 @@ database:
     - docker pull docker.elastic.co/elasticsearch/elasticsearch:5.4.0
   override:
     # start ES test database
-    - docker-compose up:
+    - docker run --rm --name elasticsearch -e ES_JAVA_OPTS="-Xms512m -Xmx512m" -p 9200:9200 -e bootstrap.memory_lock=true -e cluster.name=docker -e http.host=0.0.0.0 -e transport.host=127.0.0.1 docker.elastic.co/elasticsearch/elasticsearch:5.4.0:
         background: true
 
 test:
   override:
-    - docker-compose ps
     - tox
     # stop test ES database
-    - docker-compose stop
+    - docker stop elasticsearch
 
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ database:
 
 test:
   override:
+    - docker-compose ps
     - tox
     # stop test ES database
     - docker-compose stop

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ database:
     - docker pull docker.elastic.co/elasticsearch/elasticsearch:5.4.0
   override:
     # start ES test database
-    - docker-compose up
+    - docker-compose up:
         background: true
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,22 +1,41 @@
 # CircleCI Configuration file
 
 machine:
+  pre:
+    # install a reasonable version of Docker
+    - sudo curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   python:
       version: 2.7.11
+  services:
+    - docker
+
 
 general:
   artifacts:
      - "dist"
      - "cover"
 
+
 dependencies:
   override:
     - pip install tox tox-pyenv
     - pyenv local 2.7.11 3.5.1  # Should correspond to pre-installed Python versions on CircleCI
 
+
+database:
+  pre:
+    - docker pull docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+  override:
+    # start ES test database
+    - docker-compose up
+        background: true
+
 test:
   override:
      - tox
+    # stop test ES database
+    - docker-compose stop
+
 
 deployment:
   pypi:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+---
+version: '3'
+services:
+    elasticsearch:
+        container_name: elasticsearch
+        environment:
+            ES_JAVA_OPTS: -Xms512m -Xmx512m
+            bootstrap.memory_lock: 'true'
+            cluster.name: docker-cluster
+            http.host: 0.0.0.0
+            transport.host: 127.0.0.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+        ports:
+        - 9200:9200

--- a/microcosm_elasticsearch/assertions.py
+++ b/microcosm_elasticsearch/assertions.py
@@ -10,7 +10,11 @@ from time import sleep
 from hamcrest import assert_that, calling, raises
 
 
-def assert_that_eventually(func, matches, tries=3, sleep_seconds=0.1):
+DEFAULT_TRIES = 5
+DEFAULT_SLEEP_SECONDS = 0.1
+
+
+def assert_that_eventually(func, matches, tries=DEFAULT_TRIES, sleep_seconds=DEFAULT_SLEEP_SECONDS):
     last_error = None
     for _ in range(3):
         try:
@@ -23,7 +27,7 @@ def assert_that_eventually(func, matches, tries=3, sleep_seconds=0.1):
         raise last_error
 
 
-def assert_that_not_eventually(func, matches, tries=3, sleep_seconds=0.1):
+def assert_that_not_eventually(func, matches, tries=DEFAULT_TRIES, sleep_seconds=DEFAULT_SLEEP_SECONDS):
     assert_that(
         calling(assert_that_eventually).with_args(func, matches, tries, sleep_seconds),
         raises(AssertionError),

--- a/microcosm_elasticsearch/assertions.py
+++ b/microcosm_elasticsearch/assertions.py
@@ -10,7 +10,7 @@ from time import sleep
 from hamcrest import assert_that, calling, raises
 
 
-DEFAULT_TRIES = 5
+DEFAULT_TRIES = 3
 DEFAULT_SLEEP_SECONDS = 0.1
 
 

--- a/microcosm_elasticsearch/assertions.py
+++ b/microcosm_elasticsearch/assertions.py
@@ -1,0 +1,30 @@
+"""
+Assertion support.
+
+Elasticsearch inserts are not immediately indexed for search and count queries. For simpler
+test code, we use assertions that eventually resolve, after some number of retries.
+
+"""
+from time import sleep
+
+from hamcrest import assert_that, calling, raises
+
+
+def assert_that_eventually(func, matches, tries=3, sleep_seconds=0.1):
+    last_error = None
+    for _ in range(3):
+        try:
+            assert_that(func(), matches)
+            break
+        except Exception as error:
+            last_error = error
+        sleep(sleep_seconds)
+    else:
+        raise last_error
+
+
+def assert_that_not_eventually(func, matches, tries=3, sleep_seconds=0.1):
+    assert_that(
+        calling(assert_that_eventually).with_args(func, matches, tries, sleep_seconds),
+        raises(AssertionError),
+    )

--- a/microcosm_elasticsearch/errors.py
+++ b/microcosm_elasticsearch/errors.py
@@ -1,0 +1,73 @@
+"""
+Elasticsearch errors.
+
+Compatible with `microcosm-flask` HTTP error handling conventions.
+
+"""
+from functools import wraps
+
+from elasticsearch.exceptions import ConflictError, NotFoundError, RequestError
+
+
+def translate_elasticsearch_errors(func):
+    """
+    Translate Elasticsearch errors into HTTP compatible ones.
+
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ConflictError:
+            raise ElasticsearchConflictError
+        except NotFoundError:
+            raise ElasticsearchNotFoundError
+        except RequestError as error:
+            raise ElasticsearchError(error)
+        except KeyError as error:
+            # NB: usually caused by a missing index argument
+            raise ElasticsearchError(error)
+    return wrapper
+
+
+class ElasticsearchError(Exception):
+    """
+    Something unexpected happened.
+
+    """
+    @property
+    def status_code(self):
+        # internal server error
+        return 500
+
+
+class ElasticsearchConflictError(ElasticsearchError):
+    """
+    An attempt to create or update an entity violated a constraint.
+
+    Often expected behavior.
+
+    """
+    @property
+    def status_code(self):
+        # conflict
+        return 409
+
+    @property
+    def include_stack_trace(self):
+        return False
+
+
+class ElasticsearchNotFoundError(ElasticsearchError):
+    """
+    A supplied identifier does not refer to a known entity.
+
+    """
+    @property
+    def status_code(self):
+        # not found
+        return 404
+
+    @property
+    def include_stack_trace(self):
+        return False

--- a/microcosm_elasticsearch/indexing.py
+++ b/microcosm_elasticsearch/indexing.py
@@ -1,0 +1,29 @@
+"""
+Index management.
+
+"""
+from elasticsearch_dsl import Index
+
+
+def make_index(graph, name=None):
+    """
+    Create a new index using standard naming conventions.
+
+    In particular: uses a different index name for unit testing.
+
+    """
+    name = name or graph.metadata.name
+    if graph.metadata.testing:
+        name = "{}-test".format(name)
+
+    return Index(name=name, using=graph.elasticsearch_client)
+
+
+def createall(index, force=False):
+    """
+    Initialize the store's index.
+
+    """
+    if force and index.exists():
+        index.delete()
+    index.create()

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -1,0 +1,32 @@
+"""
+Base classes for models
+
+"""
+from elasticsearch_dsl import Date, DocType, Keyword
+
+
+class Model(DocType):
+    """
+    Every persistent entity should have a primary key id and created/updated timestamps.
+
+    """
+    id = Keyword(required=True)
+    created_at = Date(required=True)
+    updated_at = Date(required=True)
+
+    def _members(self):
+        return {
+            key: value
+            for key, value in self.to_dict().items()
+            # NB: exclude non-persistent fields
+            if key not in ("index", "doc_type")
+        }
+
+    def __eq__(self, other):
+        return type(other) is type(self) and self._members() == other._members()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return id(self) if self.id is None else hash(self.id)

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -109,6 +109,7 @@ class Store(object):
         )
         return new_instance
 
+    @translate_elasticsearch_errors
     def replace(self, identifier, new_instance):
         """
         Create or update an entity.
@@ -169,6 +170,7 @@ class Store(object):
         )
         return result["count"]
 
+    @translate_elasticsearch_errors
     def search(self, **kwargs):
         """
         Return the list of models matching some criterion.

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -1,0 +1,218 @@
+"""
+Abstraction layer for persistence operations.
+
+Allows upstream (e.g. HTTP) operations to use a consistent persistence interface
+and avoids leaking persistence abstractions throughout a code base.
+
+Intended to be duck-type compatible with `microcosm_postgres.store.Store`.
+
+"""
+from time import time
+from uuid import uuid4
+
+from microcosm_elasticsearch.errors import translate_elasticsearch_errors
+
+
+class Store(object):
+    """
+    Elasticsearch persistence interface.
+
+    """
+    def __init__(self, graph, index, doc_type):
+        """
+        :param graph: the object graph
+        :param index: the name of an index to use
+        :param doc_type: a `elasticsearch_dsl.DocType` subclass to persist.
+
+        """
+        self.elasticsearch_client = graph.elasticsearch_client
+        self.index = index
+        self.doc_type = doc_type
+
+        # register the model with the index
+        self.index.doc_type(self.doc_type)
+
+        # NB: do NOT provide a model backref here because "smart" shortcuts on the
+        # model will conflict with existing methods on the DocType base class
+
+    def new_object_id(self):
+        """
+        Injectable id generation to facilitate mocking.
+
+        Uses string-valued UUID because ES uuid support is not terrific.
+
+        """
+        return str(uuid4())
+
+    def new_timestamp(self):
+        """
+        Injectable timestamp generation to facilitate mocking.
+
+        """
+        # NB: Elasticsearch supports epoch_millis by default
+        return int(time() * 1000)
+
+    @translate_elasticsearch_errors
+    def create(self, instance):
+        """
+        Persist an entity into Elasticsearch.
+
+        """
+        now_millis = self.new_timestamp()
+
+        if instance.id is None:
+            instance.id = self.new_object_id()
+
+        instance._id = instance.id
+        instance.created_at = now_millis
+        instance.updated_at = now_millis
+
+        # NB: the DSL save function will overwrite existing records; use the raw client
+        self.elasticsearch_client.create(
+            id=instance.id,
+            index=self.index._name,
+            doc_type=self.doc_type._doc_type.name,
+            body=instance.to_dict(),
+        )
+        return instance
+
+    @translate_elasticsearch_errors
+    def retrieve(self, identifier):
+        """
+        Retrieve a model by primary key and zero or more other criteria.
+
+        :raises `ElasticsearchNotFoundError` if there is no existing model
+
+        """
+        return self.doc_type.get(
+            id=identifier,
+            index=self.index._name,
+            using=self.elasticsearch_client,
+        )
+
+    @translate_elasticsearch_errors
+    def update(self, identifier, new_instance):
+        """
+        Update an existing model with a new one.
+
+        :raises `ElasticsearchNotFoundError` if there is no existing model
+
+        """
+        new_instance.id = identifier
+        new_instance._id = identifier
+        new_instance.updated_at = self.new_timestamp()
+
+        new_instance.update(
+            using=self.elasticsearch_client,
+            index=self.index._name,
+            **new_instance.to_dict()
+        )
+        return new_instance
+
+    def replace(self, identifier, new_instance):
+        """
+        Create or update an entity.
+
+        """
+        now_millis = self.new_timestamp()
+
+        if new_instance.id is None:
+            if identifier is None:
+                identifier = self.new_object_id()
+            new_instance.id = identifier
+
+        if new_instance.created_at is None:
+            new_instance.created_at = now_millis
+
+        new_instance._id = new_instance.id
+        new_instance.updated_at = now_millis
+
+        new_instance.save(
+            id=new_instance.id,
+            using=self.elasticsearch_client,
+            index=self.index._name,
+            validate=True,
+        )
+        return new_instance
+
+    @translate_elasticsearch_errors
+    def delete(self, identifier):
+        """
+        Delete a model by primary key.
+
+        :raises `ElasticsearchNotFoundError` if there is no existing model
+
+        """
+        instance = self.doc_type(
+            _id=identifier,
+        )
+        instance.delete(
+            index=self.index._name,
+            using=self.elasticsearch_client,
+        )
+        return True
+
+    @translate_elasticsearch_errors
+    def count(self, *criterion, **kwargs):
+        """
+        Count the number of models matching some criterion.
+
+        """
+        query = self._query()
+        query = self._filter(query, **kwargs)
+
+        # NB: DSL does not have obvious count support; use the raw client
+        result = self.elasticsearch_client.count(
+            index=self.index._name,
+            doc_type=self.doc_type._doc_type.name,
+            body=query.to_dict(),
+        )
+        return result["count"]
+
+    def search(self, **kwargs):
+        """
+        Return the list of models matching some criterion.
+
+        :param offset: pagination offset, if any
+        :param limit: pagination limit, if any
+
+        """
+        query = self._query()
+        query = self._order_by(query, **kwargs)
+        query = self._filter(query, **kwargs)
+        return [
+            self.doc_type(**hit.to_dict())
+            for hit in query.execute().hits
+        ]
+
+    def _query(self):
+        """
+        Create a search query.
+
+        """
+        return self.doc_type.search(
+            index=self.index._name,
+            using=self.elasticsearch_client,
+        )
+
+    def _order_by(self, query, **kwargs):
+        """
+        Add an order by clause to a (search) query.
+
+        By default, uses reverse chronogical creation order.
+
+        """
+        return query.sort("-created_at")
+
+    def _filter(self, query, offset=None, limit=None, **kwargs):
+        """
+        Filter a query with user-supplied arguments.
+
+        :param offset: pagination offset, if any
+        :param limit: pagination limit, if any
+
+        """
+        if offset is not None and limit is not None:
+            query = query.extra(from_=offset, size=limit)
+
+        return query

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -1,0 +1,41 @@
+"""
+Test fixtures.
+
+"""
+from elasticsearch_dsl import Q, Text
+from microcosm.api import binding
+
+from microcosm_elasticsearch.indexing import make_index
+from microcosm_elasticsearch.models import Model
+from microcosm_elasticsearch.store import Store
+
+
+@binding("example_index")
+def create_example_index(graph):
+    return make_index(graph)
+
+
+class Person(Model):
+    first = Text(required=True)
+    middle = Text(required=False)
+    last = Text(required=True)
+
+
+@binding("person_store")
+class PersonStore(Store):
+    def __init__(self, graph):
+        super(PersonStore, self).__init__(graph, graph.example_index, Person)
+
+    def _filter(self, query, q=None, **kwargs):
+        if q is not None:
+            query = query.query(
+                Q(
+                    "multi_match",
+                    query=q,
+                    fields=[
+                        "first",
+                        "last",
+                    ],
+                )
+            )
+        return super(PersonStore, self)._filter(query, **kwargs)

--- a/microcosm_elasticsearch/tests/test_errors.py
+++ b/microcosm_elasticsearch/tests/test_errors.py
@@ -1,0 +1,31 @@
+"""
+Test error translation.
+
+"""
+from hamcrest import assert_that, calling, raises
+
+from elasticsearch.exceptions import ConflictError, NotFoundError, RequestError
+
+from microcosm_elasticsearch.errors import (
+    ElasticsearchError,
+    ElasticsearchConflictError,
+    ElasticsearchNotFoundError,
+    translate_elasticsearch_errors,
+)
+
+
+@translate_elasticsearch_errors
+def fixture(error):
+    raise error
+
+
+def test_error():
+    assert_that(calling(fixture).with_args(RequestError), raises(ElasticsearchError))
+
+
+def test_conflict_error():
+    assert_that(calling(fixture).with_args(ConflictError), raises(ElasticsearchConflictError))
+
+
+def test_not_found_error():
+    assert_that(calling(fixture).with_args(NotFoundError), raises(ElasticsearchNotFoundError))

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -1,0 +1,201 @@
+"""
+Test Elasticsearch persistence.
+
+"""
+from hamcrest import (
+    all_of,
+    assert_that,
+    calling,
+    contains,
+    equal_to,
+    has_property,
+    is_,
+    none,
+    raises,
+)
+from microcosm.api import create_object_graph
+
+from microcosm_elasticsearch.assertions import assert_that_eventually, assert_that_not_eventually
+from microcosm_elasticsearch.errors import (
+    ElasticsearchConflictError,
+    ElasticsearchNotFoundError,
+)
+from microcosm_elasticsearch.indexing import createall
+from microcosm_elasticsearch.tests.fixtures import Person
+
+
+class TestStore(object):
+
+    def setup(self):
+        self.graph = create_object_graph("example", testing=True)
+        self.store = self.graph.person_store
+        createall(self.graph.example_index, force=True)
+
+        self.kevin = Person(
+            first="Kevin",
+            last="Durant",
+        )
+        self.steph = Person(
+            first="Steph",
+            last="Curry",
+        )
+
+    def test_retrieve_not_found(self):
+        assert_that(
+            calling(self.store.retrieve).with_args(self.store.new_object_id()),
+            raises(ElasticsearchNotFoundError),
+        )
+
+    def test_create(self):
+        self.store.create(self.kevin)
+        assert_that(
+            self.store.retrieve(self.kevin.id),
+            all_of(
+                has_property("id", self.kevin.id),
+                has_property("first", "Kevin"),
+                has_property("middle", none()),
+                has_property("last", "Durant"),
+            ),
+        )
+
+    def test_create_duplicate(self):
+        self.store.create(self.kevin)
+        assert_that(
+            calling(self.store.create).with_args(self.kevin),
+            raises(ElasticsearchConflictError),
+        )
+
+    def test_count(self):
+        self.store.create(self.kevin)
+        self.store.create(self.steph)
+        assert_that_eventually(
+            calling(self.store.count),
+            is_(equal_to(2)),
+        )
+
+    def test_delete_not_found(self):
+        assert_that(
+            calling(self.store.delete).with_args(self.store.new_object_id()),
+            raises(ElasticsearchNotFoundError),
+        )
+
+    def test_delete(self):
+        self.store.create(self.kevin)
+        assert_that(self.store.delete(self.kevin.id), is_(equal_to(True)))
+        assert_that(
+            calling(self.store.retrieve).with_args(self.kevin.id),
+            raises(ElasticsearchNotFoundError),
+        )
+
+    def test_search(self):
+        self.store.create(self.kevin)
+        assert_that_eventually(
+            calling(self.store.search),
+            contains(
+                all_of(
+                    has_property("id", self.kevin.id),
+                    has_property("first", "Kevin"),
+                    has_property("last", "Durant"),
+                ),
+            ),
+        )
+
+    def test_search_order_reverse_chronological(self):
+        self.store.create(self.kevin)
+        self.store.create(self.steph)
+        assert_that_eventually(
+            calling(self.store.search),
+            contains(
+                has_property("id", self.steph.id),
+                has_property("id", self.kevin.id),
+            ),
+        )
+
+    def test_search_paging(self):
+        self.store.create(self.kevin)
+        self.store.create(self.steph)
+        assert_that_eventually(
+            calling(self.store.search).with_args(offset=1, limit=1),
+            contains(
+                has_property("id", self.kevin.id),
+            ),
+        )
+        assert_that_eventually(
+            calling(self.store.search).with_args(offset=0, limit=1),
+            contains(
+                has_property("id", self.steph.id),
+            ),
+        )
+
+    def test_search_filter(self):
+        self.store.create(self.kevin)
+        assert_that_eventually(
+            calling(self.store.search).with_args(q=self.kevin.first),
+            contains(
+                all_of(
+                    has_property("id", self.kevin.id),
+                    has_property("first", "Kevin"),
+                    has_property("last", "Durant"),
+                ),
+            ),
+        )
+
+    def test_search_filter_out(self):
+        self.store.create(self.kevin)
+        assert_that_not_eventually(
+            calling(self.store.search).with_args(q=self.steph.first),
+            contains(
+                all_of(
+                    has_property("id", self.kevin.id),
+                    has_property("first", "Kevin"),
+                    has_property("last", "Durant"),
+                ),
+            ),
+        )
+
+    def test_update_not_found(self):
+        assert_that(
+            calling(self.store.update).with_args(self.store.new_object_id(), self.kevin),
+            raises(ElasticsearchNotFoundError),
+        )
+
+    def test_update(self):
+        self.store.create(self.kevin)
+        self.kevin.middle = "MVP"
+        self.store.update(self.kevin.id, self.kevin)
+        assert_that(
+            self.store.retrieve(self.kevin.id),
+            all_of(
+                has_property("id", self.kevin.id),
+                has_property("first", "Kevin"),
+                has_property("middle", "MVP"),
+                has_property("last", "Durant"),
+            ),
+        )
+
+    def test_replace_not_found(self):
+        self.kevin.middle = "MVP"
+        self.store.replace(self.kevin.id, self.kevin)
+        assert_that(
+            self.store.retrieve(self.kevin.id),
+            all_of(
+                has_property("id", self.kevin.id),
+                has_property("first", "Kevin"),
+                has_property("middle", "MVP"),
+                has_property("last", "Durant"),
+            ),
+        )
+
+    def test_replace(self):
+        self.store.create(self.kevin)
+        self.kevin.middle = "MVP"
+        self.store.replace(self.kevin.id, self.kevin)
+        assert_that(
+            self.store.retrieve(self.kevin.id),
+            all_of(
+                has_property("id", self.kevin.id),
+                has_property("first", "Kevin"),
+                has_property("middle", "MVP"),
+                has_property("last", "Durant"),
+            ),
+        )

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -14,6 +14,8 @@ from hamcrest import (
     raises,
 )
 from microcosm.api import create_object_graph
+from nose.plugins.attrib import attr
+
 
 from microcosm_elasticsearch.assertions import assert_that_eventually, assert_that_not_eventually
 from microcosm_elasticsearch.errors import (
@@ -65,6 +67,7 @@ class TestStore(object):
             raises(ElasticsearchConflictError),
         )
 
+    @attr("slow")
     def test_count(self):
         self.store.create(self.kevin)
         self.store.create(self.steph)
@@ -87,6 +90,7 @@ class TestStore(object):
             raises(ElasticsearchNotFoundError),
         )
 
+    @attr("slow")
     def test_search(self):
         self.store.create(self.kevin)
         assert_that_eventually(
@@ -100,6 +104,7 @@ class TestStore(object):
             ),
         )
 
+    @attr("slow")
     def test_search_order_reverse_chronological(self):
         self.store.create(self.kevin)
         self.store.create(self.steph)
@@ -111,6 +116,7 @@ class TestStore(object):
             ),
         )
 
+    @attr("slow")
     def test_search_paging(self):
         self.store.create(self.kevin)
         self.store.create(self.steph)
@@ -127,6 +133,7 @@ class TestStore(object):
             ),
         )
 
+    @attr("slow")
     def test_search_filter(self):
         self.store.create(self.kevin)
         assert_that_eventually(
@@ -140,6 +147,7 @@ class TestStore(object):
             ),
         )
 
+    @attr("slow")
     def test_search_filter_out(self):
         self.store.create(self.kevin)
         assert_that_not_eventually(

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,12 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
-        "boto3>=1.3.1",
-        "botocore>=1.4.23",
-        "elasticsearch>=2.0.0",
-        "microcosm>=0.17.0",
-        "requests[security]>=2.9.1",
+        "boto3>=1.4.4",
+        "botocore>=1.5.59",
+        "elasticsearch>=5.4.0",
+        "elasticsearch-dsl==5.3.0",
+        "microcosm>=1.2.0",
+        "requests[security]>=2.17.3",
         "requests-aws4auth-redux>=0.40",
     ],
     setup_requires=[
@@ -34,8 +35,8 @@ setup(
         ],
     },
     tests_require=[
-        "coverage>=3.7.1",
-        "mock>=1.0.1",
-        "PyHamcrest>=1.8.5",
+        "coverage>=4.4.1",
+        "mock>=2.0.0",
+        "PyHamcrest>=1.9.0",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py35, lint
 
 [testenv]
 commands =
-    python setup.py nosetests --with-coverage --cover-package=microcosm_elasticsearch --cover-erase --cover-html
+    python setup.py nosetests --with-coverage --cover-package=microcosm_elasticsearch --cover-erase --cover-html -a '!slow'
     python setup.py sdist
 deps =
     setuptools>=17.1


### PR DESCRIPTION
Includes:
 -  A model base class with common attributes
 -  A store abstraction that parallels `microcosm-postgres.store.Store`
 -  Preliminary index management support
 -  Better unit test support in ES factoriews
 -  Example test fixtures