### PR TITLE
Remove python2isms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     # install a reasonable version of Docker
     - sudo curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   python:
-      version: 2.7.11
+      version: 3.6.2
   services:
     - docker
 
@@ -19,12 +19,12 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.1  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2  # Should correspond to pre-installed Python versions on CircleCI
 
 
 database:
   pre:
-    - docker pull docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+    - docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.5
   override:
     # start ES test database
     - docker run --rm --name elasticsearch -e ES_JAVA_OPTS="-Xms512m -Xmx512m" -p 9200:9200 -e bootstrap.memory_lock=true -e cluster.name=docker -e http.host=0.0.0.0 -e transport.host=127.0.0.1 docker.elastic.co/elasticsearch/elasticsearch:5.4.0:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
             cluster.name: docker-cluster
             http.host: 0.0.0.0
             transport.host: 127.0.0.1
-        image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.6.5
         ports:
         - 9200:9200

--- a/microcosm_elasticsearch/registry.py
+++ b/microcosm_elasticsearch/registry.py
@@ -7,7 +7,7 @@ from elasticsearch_dsl import Index
 from inflection import underscore
 
 
-class IndexRegistry(object):
+class IndexRegistry:
     """
     A registry of application indexes.
 

--- a/microcosm_elasticsearch/searching.py
+++ b/microcosm_elasticsearch/searching.py
@@ -5,7 +5,7 @@ Index search.
 from microcosm_elasticsearch.errors import translate_elasticsearch_errors
 
 
-class SearchIndex(object):
+class SearchIndex:
     """
     Encapsulates search against an index.
 

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -16,7 +16,7 @@ from microcosm_elasticsearch.errors import translate_elasticsearch_errors
 from microcosm_elasticsearch.searching import SearchIndex
 
 
-class Store(object):
+class Store:
     """
     Elasticsearch persistence interface.
 

--- a/microcosm_elasticsearch/tests/test_searching.py
+++ b/microcosm_elasticsearch/tests/test_searching.py
@@ -15,7 +15,7 @@ from microcosm.api import create_object_graph
 from microcosm_elasticsearch.tests.fixtures import Person, Player, PersonSearchIndex
 
 
-class TestIndexSearch(object):
+class TestIndexSearch:
 
     def setup(self):
         self.graph = create_object_graph("example", testing=True)

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -27,7 +27,7 @@ from microcosm_elasticsearch.errors import (
 from microcosm_elasticsearch.tests.fixtures import Person
 
 
-class TestStore(object):
+class TestStore:
 
     def setup(self):
         self.graph = create_object_graph("example", testing=True)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-elasticsearch"
-version = "0.20.0"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -16,12 +16,12 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
-        "boto3>=1.4.4",
-        "botocore>=1.5.59",
+        "boto3>=1.5.8",
+        "botocore>=1.8.22",
         "elasticsearch<6.0.0",
         "elasticsearch-dsl==5.3.0",
-        "microcosm>=1.2.0",
-        "requests[security]>=2.17.3",
+        "microcosm>=1.4.0",
+        "requests[security]>=2.18.4",
         "requests-aws4auth-redux>=0.40",
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "botocore>=1.8.22",
         "elasticsearch<6.0.0",
         "elasticsearch-dsl==5.3.0",
-        "microcosm>=1.4.0",
+        "microcosm>=2.0.0",
         "requests[security]>=2.18.4",
         "requests-aws4auth-redux>=0.40",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py36, lint
 
 [testenv]
 commands =
@@ -10,7 +10,7 @@ deps =
 
 [testenv:lint]
 commands=flake8 --max-line-length 120 microcosm_elasticsearch
-basepython=python2.7
+basepython=python3.6
 deps=
     flake8
     flake8-print


### PR DESCRIPTION
 - Build only 3.6
 - Remove six usage
 - Remove legacy class-object inheritance
 - Bump major version
 - Upgrade to ES 5.6.5 in tests