### PR TITLE
Bump libraries for ElasticSearch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 2.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -24,10 +24,10 @@ dependencies:
 
 database:
   pre:
-    - docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.5
+    - docker pull docker.elastic.co/elasticsearch/elasticsearch:6.0.1
   override:
     # start ES test database
-    - docker run --rm --name elasticsearch -e ES_JAVA_OPTS="-Xms512m -Xmx512m" -p 9200:9200 -e bootstrap.memory_lock=true -e cluster.name=docker -e http.host=0.0.0.0 -e transport.host=127.0.0.1 docker.elastic.co/elasticsearch/elasticsearch:5.4.0:
+    - docker run --rm --name elasticsearch -e ES_JAVA_OPTS="-Xms512m -Xmx512m" -p 9200:9200 -e bootstrap.memory_lock=true -e cluster.name=docker -e http.host=0.0.0.0 -e transport.host=127.0.0.1 docker.elastic.co/elasticsearch/elasticsearch:6.0.1:
         background: true
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
             cluster.name: docker-cluster
             http.host: 0.0.0.0
             transport.host: 127.0.0.1
-        image: docker.elastic.co/elasticsearch/elasticsearch:5.6.5
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.0.1
         ports:
         - 9200:9200

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -8,12 +8,23 @@ from elasticsearch_dsl.document import DocTypeOptions, DocTypeMeta
 
 class ModelMeta(DocTypeMeta):
     def __new__(cls, name, bases, attrs):
+        """
+        The logic here is the same as
+        https://github.com/elastic/elasticsearch-dsl-py/blob/master/elasticsearch_dsl/document.py#L25
+        We're overriding the metaclass to use `ModelOptions` instead of `DocTypeOptions`
+
+        """
         attrs["_doc_type"] = ModelOptions(name, bases, attrs)
         return super(DocTypeMeta, cls).__new__(cls, name, bases, attrs)
 
 
 class ModelOptions(DocTypeOptions):
     def __init__(self, name, bases, attrs):
+        """
+        Overriding this method to dynamically define a field holding the document type
+        which defines which `Model` that document should be cast to
+
+        """
         if "__doctype_field__" in attrs:
             # Dynamically set the field for polymorphic doctype
             doctype_field_name = attrs["__doctype_field__"]
@@ -24,8 +35,9 @@ class ModelOptions(DocTypeOptions):
 class Model(DocType, metaclass=ModelMeta):
     """
     Base for all models. Any model instance has a primary key and created/updated timestamps,
-    as well as a field indicating the doctype (set via the metaclass, whose value defautls to the lowercased
-    model name).
+    as well as a field indicating the doctype (set via the metaclass).
+
+    See README#polymorphic-models for more details
 
     """
     # By default when creating a document from a `Model` subclass instance

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -25,7 +25,7 @@ class ModelOptions(DocTypeOptions):
         which defines which `Model` that document should be cast to
 
         """
-        if "__doctype_field__" in attrs:
+        if "__doctype_field__" in attrs and attrs['__doctype_field__'] is not None:
             # Dynamically set the field for polymorphic doctype
             doctype_field_name = attrs["__doctype_field__"]
             attrs[doctype_field_name] = Keyword(required=True)
@@ -45,19 +45,23 @@ class Model(DocType, metaclass=ModelMeta):
     # To override this declare:
     # __doctype_name__ = "<other name>"
 
-    # The following will set up a field to hold the document's polymorphic doctype
-    # By default the field name is "doctype", override in child classes to change this
+    # Set the following to rename the "doctype" field which hold the document's polymorphic doc type
     # Note that if you change it here you should also override the SearchIndex's `mapping_type_name` property
-    __doctype_field__ = "doctype"
+    __doctype_field__ = None
 
     # Every persistent entity should have a primary key id and created/updated timestamps.
+
+    if __doctype_field__ is not None:
+        doctype = Keyword(required=True)
+
     id = Keyword(required=True)
     created_at = Date(required=True)
     updated_at = Date(required=True)
 
     def __init__(self, meta=None, **kwargs):
         cls = self.__class__
-        kwargs[cls.__doctype_field__] = cls.get_model_doctype()
+        doctype_field = cls.__doctype_field__ or "doctype"
+        kwargs[doctype_field] = cls.get_model_doctype()
         return super().__init__(meta=meta, **kwargs)
 
     @classmethod

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -3,19 +3,42 @@ Base classes for models
 
 """
 from elasticsearch_dsl import Date, DocType, Keyword
+from elasticsearch_dsl.document import DocTypeOptions, DocTypeMeta
 
 
-class Model(DocType):
+class ModelMeta(DocTypeMeta):
+    def __new__(cls, name, bases, attrs):
+        attrs["_doc_type"] = ModelOptions(name, bases, attrs)
+        return super(DocTypeMeta, cls).__new__(cls, name, bases, attrs)
+
+
+class ModelOptions(DocTypeOptions):
+    def __init__(self, name, bases, attrs):
+        if "__doctype_field__" in attrs:
+            # Dynamically set the field for polymorphic doctype
+            doctype_field_name = attrs["__doctype_field__"]
+            attrs[doctype_field_name] = Keyword(required=True)
+        super().__init__(name, bases, attrs)
+
+
+class ModelBase(DocType):
     """
     Every persistent entity should have a primary key id and created/updated timestamps.
 
-    """
-    __doc_type_field__ = "doctype"
-    # By default the doctype will be set to the class name
-    # To change this declare:
-    # __doc_type_name__ = "<other name>"
+    `ModelBase` has all the behavior we want from the `Model` base class; but since it defines
+    a __doctype_field__ we want it to avoid the special behavior defined in `ModelMeta`. This is why
+    `Model` inherits from this class and has the `ModelMeta` metaclass.
 
-    doctype = Keyword(required=True)
+    """
+    # By default when creating a document from a `Model` subclass instance
+    # Its doctype will be set to the lowercased subclass name
+    # To override this declare:
+    # __doctype_name__ = "<other name>"
+
+    # The following will set up a field to hold the document's polymorphic doctype
+    # By default the field name is "doctype", override in child classes to change this
+    # Note that if you change it here you should also override the SearchIndex's `mapping_type_name` property
+    __doctype_field__ = "doctype"
 
     id = Keyword(required=True)
     created_at = Date(required=True)
@@ -23,8 +46,12 @@ class Model(DocType):
 
     def __init__(self, meta=None, **kwargs):
         cls = self.__class__
-        kwargs["doctype"] = getattr(cls, "__doc_type_name__", None) or cls.__name__.lower()
+        kwargs[cls.__doctype_field__] = cls.get_model_doctype()
         return super().__init__(meta=meta, **kwargs)
+
+    @classmethod
+    def get_model_doctype(cls):
+        return getattr(cls, "__doctype_name__", None) or cls.__name__.lower()
 
     def _members(self):
         return {
@@ -42,3 +69,7 @@ class Model(DocType):
 
     def __hash__(self):
         return id(self) if self.id is None else hash(self.id)
+
+
+class Model(ModelBase, metaclass=ModelMeta):
+    pass

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -10,9 +10,21 @@ class Model(DocType):
     Every persistent entity should have a primary key id and created/updated timestamps.
 
     """
+    __doc_type_field__ = "doctype"
+    # By default the doctype will be set to the class name
+    # To change this declare:
+    # __doc_type_name__ = "<other name>"
+
+    doctype = Keyword(required=True)
+
     id = Keyword(required=True)
     created_at = Date(required=True)
     updated_at = Date(required=True)
+
+    def __init__(self, meta=None, **kwargs):
+        cls = self.__class__
+        kwargs["doctype"] = getattr(cls, "__doc_type_name__", None) or cls.__name__.lower()
+        return super().__init__(meta=meta, **kwargs)
 
     def _members(self):
         return {

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -21,13 +21,11 @@ class ModelOptions(DocTypeOptions):
         super().__init__(name, bases, attrs)
 
 
-class ModelBase(DocType):
+class Model(DocType, metaclass=ModelMeta):
     """
-    Every persistent entity should have a primary key id and created/updated timestamps.
-
-    `ModelBase` has all the behavior we want from the `Model` base class; but since it defines
-    a __doctype_field__ we want it to avoid the special behavior defined in `ModelMeta`. This is why
-    `Model` inherits from this class and has the `ModelMeta` metaclass.
+    Base for all models. Any model instance has a primary key and created/updated timestamps,
+    as well as a field indicating the doctype (set via the metaclass, whose value defautls to the lowercased
+    model name).
 
     """
     # By default when creating a document from a `Model` subclass instance
@@ -40,6 +38,7 @@ class ModelBase(DocType):
     # Note that if you change it here you should also override the SearchIndex's `mapping_type_name` property
     __doctype_field__ = "doctype"
 
+    # Every persistent entity should have a primary key id and created/updated timestamps.
     id = Keyword(required=True)
     created_at = Date(required=True)
     updated_at = Date(required=True)
@@ -69,7 +68,3 @@ class ModelBase(DocType):
 
     def __hash__(self):
         return id(self) if self.id is None else hash(self.id)
-
-
-class Model(ModelBase, metaclass=ModelMeta):
-    pass

--- a/microcosm_elasticsearch/searching.py
+++ b/microcosm_elasticsearch/searching.py
@@ -23,18 +23,35 @@ class SearchIndex:
         same type.
 
     """
-    def __init__(self, graph, index, model_class, doc_type=None):
+    @property
+    def doc_type_field(self):
+        """
+        Defines document field used to determine the document's polymorphic type in a single-mapping-type index
+
+        """
+        return "doctype"
+
+    def __init__(self, graph, index, doc_type=None):
         """
         :param graph: the object graph
         :param index: the name of an index to use
-        :param model_class: the model to return in the results list
         :param doc_type: the doc type to search for; uses the index's doc types if omitted
 
         """
         self.elasticsearch_client = graph.elasticsearch_client
         self.index = index
-        self.model_class = model_class
-        self.doc_type = doc_type
+        # Mapping from ES custom type field to corresponding model class
+        self.doc_types = dict()
+        if doc_type is not None:
+            self.register_doc_type(doc_type)
+
+
+    def register_doc_type(self, model_class):
+        if hasattr(model_class, "__doc_type__"):
+            doc_type = model_class.__doc_type__
+        else:
+            doc_type = model_class.__name__.lower()
+        self.doc_types[doc_type] = model_class
 
     @property
     def index_name(self):
@@ -85,6 +102,11 @@ class SearchIndex:
         Resolve this hit into a model instance.
 
         """
+        hit_doc_type = getattr(hit, self.doc_type_field, None)
+        hit_model_class = self.doc_types.get(hit_doc_type)
+        if hit_doc_type is not None and hit_model_class is not None:
+            return  hit_model_class(**hit._d_)
+        # Will return be a generic `Hit`
         return hit
 
     def _to_list(self, results):
@@ -101,12 +123,11 @@ class SearchIndex:
         """
         Create a search query.
 
-        Starts with the index's search function. Customizes with the provided doc type, if any.
+        Starts with the index's search function; customizes with the provided doc types, if any
 
         """
         query = self.index.search()
-        if self.doc_type is not None:
-            query = query.doc_type().doc_type(self.doc_type)
+        query = query.filter("terms", **{self.doc_type_field: [type_name for type_name in self.doc_types]})
         return query
 
     def _order_by(self, query, **kwargs):
@@ -136,4 +157,4 @@ class SearchIndex:
 
     @classmethod
     def for_only(cls, graph, index, doc_type):
-        return cls(graph, index, doc_type, doc_type)
+        return cls(graph, index, doc_type)

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -13,7 +13,6 @@ from time import time
 from uuid import uuid4
 
 from microcosm_elasticsearch.errors import translate_elasticsearch_errors
-from microcosm_elasticsearch.searching import SearchIndex
 
 
 class Store:
@@ -21,7 +20,7 @@ class Store:
     Elasticsearch persistence interface.
 
     """
-    def __init__(self, graph, index, model_class, search_index=SearchIndex):
+    def __init__(self, graph, index, model_class, search_index):
         """
         :param graph: the object graph
         :param index: the name of an index to use
@@ -32,13 +31,8 @@ class Store:
         self.index = index
         self.model_class = model_class
 
-        if isclass(search_index):
-            self.search_index = search_index(graph, index, model_class)
-        else:
-            self.search_index = search_index
-
-        # register the model with the index
-        self.index.doc_type(self.model_class)
+        search_index.register_doc_type(model_class)
+        self.search_index = search_index
 
         # NB: do NOT provide a model backref here because "smart" shortcuts on the
         # model will conflict with existing methods on the DocType base class

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -8,7 +8,6 @@ Intended to be duck-type compatible with `microcosm_postgres.store.Store`.
 
 """
 from contextlib import contextmanager
-from inspect import isclass
 from time import time
 from uuid import uuid4
 

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -16,7 +16,6 @@ def create_example_index(graph):
 
 
 class Person(Model):
-    doctype = Keyword(required=True)
     first = Text(required=True)
     middle = Text(required=False)
     last = Text(required=True)

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -16,6 +16,7 @@ def create_example_index(graph):
 
 
 class Person(Model):
+    doctype = Keyword(required=True)
     first = Text(required=True)
     middle = Text(required=False)
     last = Text(required=True)
@@ -46,17 +47,16 @@ def create_example_search_index(graph):
     return PersonSearchIndex(
         graph=graph,
         index=graph.example_index,
-        model_class=Person,
     )
 
 
 @binding("person_store")
 class PersonStore(Store):
     def __init__(self, graph):
-        super(PersonStore, self).__init__(graph, graph.example_index, Person, PersonSearchIndex)
+        super(PersonStore, self).__init__(graph, graph.example_index, Person, graph.example_search_index)
 
 
 @binding("player_store")
 class PlayerStore(Store):
     def __init__(self, graph):
-        super(PlayerStore, self).__init__(graph, graph.example_index, Player, PersonSearchIndex)
+        super(PlayerStore, self).__init__(graph, graph.example_index, Player, graph.example_search_index)

--- a/microcosm_elasticsearch/tests/test_mapping.py
+++ b/microcosm_elasticsearch/tests/test_mapping.py
@@ -1,0 +1,116 @@
+"""
+Test that the way we define a SearchIndex, Store and Model is consistent when overriding defaults
+
+The fixtures below are the same as in fixtures.py, but we override defaults to set a different name for the
+mapping type and doctype field
+
+"""
+from elasticsearch_dsl import Keyword, Text
+from hamcrest import assert_that, all_of, contains_inanyorder, has_length, has_property, instance_of
+from microcosm.api import create_object_graph
+from microcosm.decorators import binding
+
+from microcosm_elasticsearch.models import Model
+from microcosm_elasticsearch.searching import SearchIndex
+from microcosm_elasticsearch.store import Store
+
+
+@binding("other_example_index")
+def create_other_example_index(graph):
+    return graph.elasticsearch_index_registry.register(version="v1")
+
+
+class OtherPerson(Model):
+    __doctype_field__ = "other_doctype"
+    __doctype_name__ = "modified_person"
+
+    class Meta:
+        doc_type = "different_mapping"
+
+    first = Text(required=True)
+    middle = Text(required=False)
+    last = Text(required=True)
+
+
+class OtherPlayer(OtherPerson):
+    __doctype_name__ = "modified_player"
+
+    jersey_number = Keyword(required=False)
+
+    class Meta:
+        doc_type = "different_mapping"
+
+
+class OtherPersonSearchIndex(SearchIndex):
+    @property
+    def mapping_type_name(self):
+        return "different_mapping"
+
+    @property
+    def doc_type_field(self):
+        return "other_doctype"
+
+
+@binding("other_search_index")
+def create_other_search_index(graph):
+    return OtherPersonSearchIndex(
+        graph=graph,
+        index=graph.other_example_index,
+    )
+
+
+@binding("other_person_store")
+class OtherPersonStore(Store):
+    def __init__(self, graph):
+        super(OtherPersonStore, self).__init__(graph, graph.other_example_index, OtherPerson, graph.other_search_index)
+
+
+@binding("other_player_store")
+class OtherPlayerStore(Store):
+    def __init__(self, graph):
+        super(OtherPlayerStore, self).__init__(graph, graph.other_example_index, OtherPlayer, graph.other_search_index)
+
+
+class TestMapping:
+    def setup(self):
+        self.graph = create_object_graph("example", testing=True)
+        self.other_person_store = self.graph.other_person_store
+        self.other_player_store = self.graph.other_player_store
+        self.search_index = self.graph.other_search_index
+        self.graph.elasticsearch_index_registry.createall(force=True)
+
+        self.kevin = OtherPerson(
+            first="Kevin",
+            last="Durant",
+        )
+        self.steph = OtherPlayer(
+            first="Steph",
+            last="Curry",
+        )
+
+    def test_mapping(self):
+        with self.other_person_store.flushing():
+            self.graph.other_person_store.create(self.kevin)
+        with self.other_player_store.flushing():
+            self.graph.other_player_store.create(self.steph)
+        result = self.search_index.search()
+
+        assert_that(
+            result,
+            has_length(2),
+        )
+
+        # Results are cast to the correct class according to their doctypes
+        assert_that(
+            result,
+            contains_inanyorder(
+                all_of(
+                    has_property("other_doctype", "modified_person"),
+                    instance_of(OtherPerson)
+                ),
+                all_of(
+                    has_property("other_doctype", "modified_player"),
+                    instance_of(OtherPlayer),
+                ),
+            )
+        )

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -152,7 +152,7 @@ class TestStore:
             self.store.create(self.kevin)
             with patch.object(self.store, "new_timestamp") as mocked:
                 # ensure we have >= 1s created at delta
-                mocked.return_value = self.kevin.created_at + timedelta(seconds=1)
+                mocked.return_value = self.kevin.created_at + timedelta(seconds=1).seconds * 1000
                 self.store.create(self.steph)
 
         assert_that(
@@ -168,7 +168,7 @@ class TestStore:
             self.store.create(self.kevin)
             with patch.object(self.store, "new_timestamp") as mocked:
                 # ensure we have >= 1s created at delta
-                mocked.return_value = self.kevin.created_at + timedelta(seconds=1)
+                mocked.return_value = self.kevin.created_at + timedelta(seconds=1).seconds * 1000
                 self.store.create(self.steph)
 
         assert_that(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-elasticsearch"
-version = "1.0.0"
+version = "2.0.0"
 
 setup(
     name=project,
@@ -20,8 +20,6 @@ setup(
         "botocore>=1.8.22",
         "elasticsearch>=6.0.0,<7.0.0",
         "elasticsearch-dsl==6.0.0",
-        # "elasticsearch<6.0.0",
-        # "elasticsearch-dsl==5.3.0",
         "microcosm>=2.0.0",
         "requests[security]>=2.18.4",
         "requests-aws4auth-redux>=0.40",

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     install_requires=[
         "boto3>=1.5.8",
         "botocore>=1.8.22",
-        "elasticsearch<6.0.0",
-        "elasticsearch-dsl==5.3.0",
+        "elasticsearch>=6.0.0,<7.0.0",
+        "elasticsearch-dsl==6.0.0",
         "microcosm>=2.0.0",
         "requests[security]>=2.18.4",
         "requests-aws4auth-redux>=0.40",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
         "botocore>=1.8.22",
         "elasticsearch>=6.0.0,<7.0.0",
         "elasticsearch-dsl==6.0.0",
+        # "elasticsearch<6.0.0",
+        # "elasticsearch-dsl==5.3.0",
         "microcosm>=2.0.0",
         "requests[security]>=2.18.4",
         "requests-aws4auth-redux>=0.40",


### PR DESCRIPTION
Add support for multi-type index mapping and bump `elasticsearch_dsl` version.

Starting with ES6 indices are expected to only have one mapping type. This means that to put polymorphic documents in a single index one can 1. Have one index per type 2. Create a custom type field in the
 index mapping.
The first case is not a problem but the second case is not well handled by `elasticsearch_dsl`, as it still ties object polymorphism (on the application side) to mapping type (on the ES side). This PR add
s support for defining polymorphic document types in a single ES mapping type. Specifically:
- A `SearchIndex` defines the name of its mapping type ("doc" by default) and custom document type field (defaults to "doctype").
- Each `Model` defines the value its document type field will have (defaults to the lowercased model name)
- Each `Store` registers its `Model` subclass with the `SearchIndex`. From those the `SearchIndex` builds a unified mapping
- When carrying out a search against an index, the `SearchIndex` takes care of casting each result to the right `Model` instance using the document type field.

Note that the mapping type name and document type field name have to be defined both on the `Model` and the `SearchIndex`. As such, if the defaults are overriden, they should be overriden consistently on the `SearchIndex` and any `Model` subclass that the index will hold.

**Note:** Most of the changes made here should really be folded into `elasticsearch_dsl`, which would require that they separate the concept of document type from the ElasticSearch mapping type. I made a comment in https://github.com/elastic/elasticsearch-dsl-py/issues/800 and am waiting to hear back.