### PR TITLE
Remove possibility to change a model's doc type field name

### DIFF
--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -3,65 +3,33 @@ Base classes for models
 
 """
 from elasticsearch_dsl import Date, DocType, Keyword
-from elasticsearch_dsl.document import DocTypeOptions, DocTypeMeta
 
 
-class ModelMeta(DocTypeMeta):
-    def __new__(cls, name, bases, attrs):
-        """
-        The logic here is the same as
-        https://github.com/elastic/elasticsearch-dsl-py/blob/master/elasticsearch_dsl/document.py#L25
-        We're overriding the metaclass to use `ModelOptions` instead of `DocTypeOptions`
-
-        """
-        attrs["_doc_type"] = ModelOptions(name, bases, attrs)
-        return super(DocTypeMeta, cls).__new__(cls, name, bases, attrs)
-
-
-class ModelOptions(DocTypeOptions):
-    def __init__(self, name, bases, attrs):
-        """
-        Overriding this method to dynamically define a field holding the document type
-        which defines which `Model` that document should be cast to
-
-        """
-        if "__doctype_field__" in attrs and attrs['__doctype_field__'] is not None:
-            # Dynamically set the field for polymorphic doctype
-            doctype_field_name = attrs["__doctype_field__"]
-            attrs[doctype_field_name] = Keyword(required=True)
-        super().__init__(name, bases, attrs)
-
-
-class Model(DocType, metaclass=ModelMeta):
+class Model(DocType):
     """
     Base for all models. Any model instance has a primary key and created/updated timestamps,
-    as well as a field indicating the doctype (set via the metaclass).
+    as well as a field indicating the doctype.
 
     See README#polymorphic-models for more details
 
     """
     # By default when creating a document from a `Model` subclass instance
-    # Its doctype will be set to the lowercased subclass name
+    # Its `"doctype"` field will be set to the lowercased subclass name
     # To override this declare:
     # __doctype_name__ = "<other name>"
 
-    # Set the following to rename the "doctype" field which hold the document's polymorphic doc type
-    # Note that if you change it here you should also override the SearchIndex's `mapping_type_name` property
-    __doctype_field__ = None
-
     # Every persistent entity should have a primary key id and created/updated timestamps.
-
-    if __doctype_field__ is not None:
-        doctype = Keyword(required=True)
-
     id = Keyword(required=True)
     created_at = Date(required=True)
     updated_at = Date(required=True)
 
+    # In ES6+ indices have a single mapping type
+    # To allow for polymorphic documents, we define a field holding the document type
+    doctype = Keyword(required=True)
+
     def __init__(self, meta=None, **kwargs):
         cls = self.__class__
-        doctype_field = cls.__doctype_field__ or "doctype"
-        kwargs[doctype_field] = cls.get_model_doctype()
+        kwargs["doctype"] = cls.get_model_doctype()
         return super().__init__(meta=meta, **kwargs)
 
     @classmethod


### PR DESCRIPTION
To allow having polymorphic documents in a single-type index, we added a field to the base `Model` class that declares what type the document has. That field is named "doctype" by default, but the possibility was left to override the name. However, leaving that possibility:
-  Makes the code quite a bit less clear, since it involves dynamically setting an attribute on the metaclass (see [here](https://github.com/globality-corp/microcosm-elasticsearch/blob/970aa4c1c24d6f84edda39742659e7badfac6245/microcosm_elasticsearch/models.py#L9))
- Does not play nice with inheritance: the logic in the metaclass runs once for `Model` and each of its subclasses, when we'd like to only set the field in the leaf child class.
- Brings little value.

For those reasons, we've decided to simplify the code and always call that doc type field "doctype", without the ability to change it.