### PR TITLE
Add bulk support for elasticsearch

### DIFF
--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -236,7 +236,7 @@ class Store:
             )
             for action, instance in actions
         ]
-        
+
         return [
             bulk(
                 client=self.elasticsearch_client,

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -268,3 +268,20 @@ class TestStore:
                 has_property("last", "Durant"),
             ),
         )
+
+    def test_bulk(self):
+        self.store.bulk(
+            actions=[
+                ("index", self.kevin)
+            ],
+            batch_size=1,
+        )
+        assert_that(
+            self.store.retrieve(self.kevin.id),
+            all_of(
+                has_property("id", self.kevin.id),
+                has_property("first", "Kevin"),
+                has_property("middle", none()),
+                has_property("last", "Durant"),
+            ),
+        )

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -10,6 +10,8 @@ from hamcrest import (
     contains,
     equal_to,
     has_property,
+    has_key,
+    has_entry,
     is_,
     none,
     raises,
@@ -285,3 +287,29 @@ class TestStore:
                 has_property("last", "Durant"),
             ),
         )
+
+    def test_bulk_with_report(self):
+        results = self.store.bulk(
+            actions=[
+                ("index", self.kevin),
+                ("delete", self.steph),
+            ],
+            batch_size=2,
+        )
+        assert_that(
+            self.store.retrieve(self.kevin.id),
+            all_of(
+                has_property("id", self.kevin.id),
+                has_property("first", "Kevin"),
+                has_property("middle", none()),
+                has_property("last", "Durant"),
+            ),
+        )
+        result = results[0]
+        # Updated items
+        assert_that(result[0], is_(equal_to(1)))
+        # Report on failed to delete items
+        assert_that(result[1], contains(
+            has_key('delete'),
+        ))
+        assert_that(result[1][0]['delete'], has_entry('result', 'not_found'))


### PR DESCRIPTION
* Batches bulk operation based on batch size
* Does not fail if an individual operation in the bulk fails
* Report of how many records were updated and the possible failures is returned