### PR TITLE
Allow running createall on existing index

### DIFF
--- a/microcosm_elasticsearch/registry.py
+++ b/microcosm_elasticsearch/registry.py
@@ -67,13 +67,8 @@ class IndexRegistry:
             if force and index.exists():
                 index.delete()
                 index.flush(ignore_unavailable=True)
-            try:
-                index.create()
-                index.refresh()
-            except RequestError as error:
-                if "index_already_exists_exception" in str(error):
-                    continue
-                raise
+            index.save()
+            index.refresh()
 
     @staticmethod
     def name_for(graph, name=None, version=None):

--- a/microcosm_elasticsearch/registry.py
+++ b/microcosm_elasticsearch/registry.py
@@ -2,7 +2,6 @@
 Manage a set of indexes and/or aliases.
 
 """
-from elasticsearch.exceptions import RequestError
 from elasticsearch_dsl import Index
 from inflection import underscore
 


### PR DESCRIPTION
With `index.create`, we get an error if the index already exists. This forces us to delete the index to update its mapping after a model change. Instead we can use `index.save`, which creates the index if it doesn't exist, and updates the mapping with the latest model definition otherwise (see https://github.com/elastic/elasticsearch-dsl-py/blob/master/elasticsearch_dsl/index.py#L201).

This is unless we had another reason not to use `index.save`.