### PR TITLE
Add convention routes for indexes

### DIFF
--- a/microcosm_elasticsearch/index_status/convention.py
+++ b/microcosm_elasticsearch/index_status/convention.py
@@ -1,0 +1,37 @@
+"""
+Index Status convention.
+
+"""
+from marshmallow import Schema
+
+from microcosm_flask.conventions.base import EndpointDefinition
+from microcosm_flask.conventions.crud import configure_crud
+from microcosm_flask.operations import Operation
+from microcosm_flask.namespaces import Namespace
+from microcosm_elasticsearch.index_status.resources import (
+    IndexStatusSchema,
+)
+from microcosm_elasticsearch.index_status.store import IndexStatusStore
+
+
+def configure_status_convention(graph):
+    store = IndexStatusStore(graph)
+
+    ns = Namespace(
+        subject="index_status",
+    )
+
+    def search(**kwargs):
+        status = store.get_status()
+        return status, len(status)
+
+    mappings = {
+        Operation.Search: EndpointDefinition(
+            func=search,
+            request_schema=Schema(),
+            response_schema=IndexStatusSchema(),
+        ),
+    }
+
+    configure_crud(graph, ns, mappings)
+    return ns

--- a/microcosm_elasticsearch/index_status/models.py
+++ b/microcosm_elasticsearch/index_status/models.py
@@ -11,8 +11,10 @@ class IndexStatus:
         aliases,
         mapping,
         stats,
+        settings,
     ):
         self.name = name
         self.aliases = aliases
         self.mapping = mapping
         self.stats = stats
+        self.settings = settings

--- a/microcosm_elasticsearch/index_status/models.py
+++ b/microcosm_elasticsearch/index_status/models.py
@@ -1,0 +1,18 @@
+"""
+Synthetic object containing information about an index.
+
+"""
+
+
+class IndexStatus:
+    def __init__(
+        self,
+        name,
+        aliases,
+        mapping,
+        stats,
+    ):
+        self.name = name
+        self.aliases = aliases
+        self.mapping = mapping
+        self.stats = stats

--- a/microcosm_elasticsearch/index_status/models.py
+++ b/microcosm_elasticsearch/index_status/models.py
@@ -8,13 +8,9 @@ class IndexStatus:
     def __init__(
         self,
         name,
-        aliases,
-        mapping,
+        data,
         stats,
-        settings,
     ):
         self.name = name
-        self.aliases = aliases
-        self.mapping = mapping
+        self.data = data
         self.stats = stats
-        self.settings = settings

--- a/microcosm_elasticsearch/index_status/resources.py
+++ b/microcosm_elasticsearch/index_status/resources.py
@@ -35,3 +35,4 @@ class IndexStatusSchema(Schema):
     )
     name = fields.String()
     stats = fields.Nested(StatsSchema)
+    settings = fields.Raw()

--- a/microcosm_elasticsearch/index_status/resources.py
+++ b/microcosm_elasticsearch/index_status/resources.py
@@ -1,0 +1,37 @@
+"""
+Index Status resources.
+
+"""
+from marshmallow import fields, Schema
+
+
+class FieldSchema(Schema):
+    name = fields.String()
+    data_type = fields.String()
+
+
+class DocsSchema(Schema):
+    count = fields.Int()
+    deleted = fields.Int()
+
+
+class IndexingSchema(Schema):
+    index_current = fields.Int()
+    index_failed = fields.Int()
+    index_total = fields.Int()
+    delete_current = fields.Int()
+    delete_total = fields.Int()
+
+
+class StatsSchema(Schema):
+    docs = fields.Nested(DocsSchema)
+    indexing = fields.Nested(IndexingSchema)
+
+
+class IndexStatusSchema(Schema):
+    aliases = fields.List(fields.String)
+    mapping = fields.List(
+        fields.Nested(FieldSchema)
+    )
+    name = fields.String()
+    stats = fields.Nested(StatsSchema)

--- a/microcosm_elasticsearch/index_status/resources.py
+++ b/microcosm_elasticsearch/index_status/resources.py
@@ -5,34 +5,7 @@ Index Status resources.
 from marshmallow import fields, Schema
 
 
-class FieldSchema(Schema):
-    name = fields.String()
-    data_type = fields.String()
-
-
-class DocsSchema(Schema):
-    count = fields.Int()
-    deleted = fields.Int()
-
-
-class IndexingSchema(Schema):
-    index_current = fields.Int()
-    index_failed = fields.Int()
-    index_total = fields.Int()
-    delete_current = fields.Int()
-    delete_total = fields.Int()
-
-
-class StatsSchema(Schema):
-    docs = fields.Nested(DocsSchema)
-    indexing = fields.Nested(IndexingSchema)
-
-
 class IndexStatusSchema(Schema):
-    aliases = fields.List(fields.String)
-    mapping = fields.List(
-        fields.Nested(FieldSchema)
-    )
     name = fields.String()
-    stats = fields.Nested(StatsSchema)
-    settings = fields.Raw()
+    data = fields.Raw()
+    stats = fields.Raw()

--- a/microcosm_elasticsearch/index_status/store.py
+++ b/microcosm_elasticsearch/index_status/store.py
@@ -37,7 +37,8 @@ class IndexStatusStore:
                     name=name,
                     aliases=aliases,
                     mapping=mapping,
-                    stats=stats
+                    stats=stats,
+                    settings=data["settings"],
                 )
             )
         return indices

--- a/microcosm_elasticsearch/index_status/store.py
+++ b/microcosm_elasticsearch/index_status/store.py
@@ -1,0 +1,55 @@
+"""
+Index Status Store
+
+"""
+from microcosm_elasticsearch.index_status.models import IndexStatus
+
+
+class IndexStatusStore:
+
+    def __init__(self, graph):
+        self.index_registry = graph.elasticsearch_index_registry
+
+    def process_status_data(self, status, stats, index):
+        """
+        There is a known structure to how ES returns data about itself
+        Extract interesting properties to share for introspection
+
+        """
+        indices = []
+        for name, data in status.items():
+            aliases = [
+                alias for alias
+                in data["aliases"].keys()
+            ]
+            mapping = [
+                dict(name=field, data_type=info["type"])
+                for mapping_type in data["mappings"].keys()
+                for field, info in data["mappings"][mapping_type]["properties"].items()
+            ]
+            index_stats = stats["indices"][name]["total"]
+            stats = dict(
+                docs=index_stats["docs"],
+                indexing=index_stats["indexing"]
+            )
+            indices.append(
+                IndexStatus(
+                    name=name,
+                    aliases=aliases,
+                    mapping=mapping,
+                    stats=stats
+                )
+            )
+        return indices
+
+    def get_status(self):
+        indices = []
+        for key, index in self.index_registry.indexes.items():
+            indices.extend(
+                self.process_status_data(
+                    status=index.get(),
+                    stats=index.stats(),
+                    index=index,
+                )
+            )
+        return indices

--- a/microcosm_elasticsearch/index_status/store.py
+++ b/microcosm_elasticsearch/index_status/store.py
@@ -10,35 +10,18 @@ class IndexStatusStore:
     def __init__(self, graph):
         self.index_registry = graph.elasticsearch_index_registry
 
-    def process_status_data(self, status, stats, index):
+    def process_status_data(self, status, stats):
         """
-        There is a known structure to how ES returns data about itself
-        Extract interesting properties to share for introspection
+        Iterate through returned data and return related stats
 
         """
         indices = []
         for name, data in status.items():
-            aliases = [
-                alias for alias
-                in data["aliases"].keys()
-            ]
-            mapping = [
-                dict(name=field, data_type=info["type"])
-                for mapping_type in data["mappings"].keys()
-                for field, info in data["mappings"][mapping_type]["properties"].items()
-            ]
-            index_stats = stats["indices"][name]["total"]
-            stats = dict(
-                docs=index_stats["docs"],
-                indexing=index_stats["indexing"]
-            )
             indices.append(
                 IndexStatus(
                     name=name,
-                    aliases=aliases,
-                    mapping=mapping,
-                    stats=stats,
-                    settings=data["settings"],
+                    data=data,
+                    stats=stats['indices'][name]
                 )
             )
         return indices
@@ -50,7 +33,6 @@ class IndexStatusStore:
                 self.process_status_data(
                     status=index.get(),
                     stats=index.stats(),
-                    index=index,
                 )
             )
         return indices

--- a/microcosm_elasticsearch/tests/test_index_status_convention.py
+++ b/microcosm_elasticsearch/tests/test_index_status_convention.py
@@ -1,0 +1,27 @@
+"""
+Index status convention tests.
+
+"""
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm.api import create_object_graph
+
+
+def test_index_status():
+    """
+    Default index status check returns OK.
+
+    """
+    graph = create_object_graph(name="test", testing=True)
+    graph.use("index_status_convention")
+    graph.elasticsearch_index_registry.createall(force=True)
+
+    client = graph.flask.test_client()
+
+    response = client.get("/api/index_status")
+    assert_that(response.status_code, is_(equal_to(200)))

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "elasticsearch>=6.0.0,<7.0.0",
         "elasticsearch-dsl==6.0.0",
         "microcosm>=2.4.0",
+        "microcosm-flask>=1.0.1",
         "requests[security]>=2.18.4",
         "requests-aws4auth-redux>=0.40",
     ],
@@ -32,6 +33,7 @@ setup(
         "microcosm.factories": [
             "elasticsearch_client = microcosm_elasticsearch.factories:configure_elasticsearch_client",
             "elasticsearch_index_registry = microcosm_elasticsearch.registry:IndexRegistry",
+            "index_status_convention = microcosm_elasticsearch.index_status.convention:configure_status_convention",
         ],
     },
     tests_require=[


### PR DESCRIPTION
Why?

In microcosm-elasticsearch applications, we often want to have basic reporting on the status of the index.
This includes the current mapping, indexing stats, and aliases