### PR TITLE
Add EnumField type

### DIFF
--- a/microcosm_elasticsearch/fields.py
+++ b/microcosm_elasticsearch/fields.py
@@ -11,6 +11,8 @@ class EnumField(Keyword):
     def __init__(self, enum_class, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Leading underscore prevents attribute from being added to document in ElasticSearch
+        if not issubclass(enum_class, Enum):
+            raise TypeError("The class passed into an EnumField should a subclass of Enum")
         self._enum_class = enum_class
 
     def _serialize(self, data):

--- a/microcosm_elasticsearch/fields.py
+++ b/microcosm_elasticsearch/fields.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from elasticsearch_dsl import Keyword
+from elasticsearch_dsl.exceptions import ValidationException
+
+
+class EnumField(Keyword):
+    # Force serialization
+    _coerce = True
+    name = "keyword"
+
+    def __init__(self, enum_class, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Leading underscore prevents attribute from being added to document in ElasticSearch
+        self._enum_class = enum_class
+
+    def _serialize(self, data):
+        return str(data)
+
+    def _deserialize(self, data):
+        return self._enum_class[data]
+
+    def clean(self, data):
+        """
+        Field validation
+        Handle both cases where the data comes in as a string or enum
+
+        """
+        if isinstance(data, str):
+            return super().clean(data)
+        elif isinstance(data, Enum):
+            if data not in self._enum_class:
+                raise ValidationException(f"Value should be a member of {self.enum_class}")
+            return data
+        else:
+            raise ValidationException(f"Value of type {data.__class__} is not acceptable for an EnumField")

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -2,12 +2,24 @@
 Test fixtures.
 
 """
+from enum import Enum
+
 from elasticsearch_dsl import Keyword, Q, Text
 from microcosm.api import binding
 
 from microcosm_elasticsearch.models import Model
 from microcosm_elasticsearch.searching import SearchIndex
 from microcosm_elasticsearch.store import Store
+
+from microcosm_elasticsearch.fields import EnumField
+
+
+class Planet(Enum):
+    EARTH = "EARTH"
+    MARS = "MARS"
+
+    def __str__(self):
+        return self.name
 
 
 @binding("example_index")
@@ -19,6 +31,8 @@ class Person(Model):
     first = Text(required=True)
     middle = Text(required=False)
     last = Text(required=True)
+
+    origin_planet = EnumField(Planet)
 
 
 class Player(Person):

--- a/microcosm_elasticsearch/tests/test_mapping.py
+++ b/microcosm_elasticsearch/tests/test_mapping.py
@@ -145,6 +145,8 @@ class TestMapping:
                     "jersey_number": {"type": "keyword"},
                     "last": {"type": "text"},
                     "middle": {"type": "text"},
+                    # EnumField should have a mapping type of 'keyword'
+                    "origin_planet": {"type": "keyword"},
                     "doctype": {"type": "keyword"},
                     "updated_at": {"type": "date"},
                 })

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -26,7 +26,7 @@ from microcosm_elasticsearch.errors import (
     ElasticsearchConflictError,
     ElasticsearchNotFoundError,
 )
-from microcosm_elasticsearch.tests.fixtures import Person
+from microcosm_elasticsearch.tests.fixtures import Person, Planet
 
 
 class TestStore:
@@ -39,10 +39,12 @@ class TestStore:
         self.kevin = Person(
             first="Kevin",
             last="Durant",
+            origin_planet=Planet.EARTH,
         )
         self.steph = Person(
             first="Steph",
             last="Curry",
+            origin_planet=Planet.MARS,
         )
 
     def test_retrieve_not_found(self):
@@ -60,6 +62,7 @@ class TestStore:
                 has_property("first", "Kevin"),
                 has_property("middle", none()),
                 has_property("last", "Durant"),
+                has_property("origin_planet", Planet.EARTH),
             ),
         )
 


### PR DESCRIPTION
For enum-valued fields, we want to have an enum member on the application side, but need to serialize it to a string (with mapping type 'keyword') before saving it to elasticsearch. This takes care of that.