### PR TITLE
Convert time out to be typed

### DIFF
--- a/microcosm_elasticsearch/factories.py
+++ b/microcosm_elasticsearch/factories.py
@@ -57,7 +57,7 @@ def awsv4sign(r, *, session, region):
     username="elastic",
     password="changeme",
     use_aws4auth=typed(boolean, default_value=False),
-    timeout_seconds=10,
+    timeout_seconds=typed(int, 10),
 )
 def configure_elasticsearch_client(graph):
     """


### PR DESCRIPTION
Why?

If it isn't typed it is treats passed in config as a string which causes the client to fail