### PR TITLE
Elasticsearch 7.x compatability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
       - run:
           name: pull and run Elasticsearch
           command: |
-            docker pull docker.elastic.co/elasticsearch/elasticsearch:5.3.1
-            docker run -d --name elasticsearch -e ES_JAVA_OPTS="-Xms512m -Xmx512m" -p 9200:9200 -e bootstrap.memory_lock=true -e cluster.name=docker -e http.host=0.0.0.0 -e transport.host=127.0.0.1 docker.elastic.co/elasticsearch/elasticsearch:5.3.1
+            docker pull docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+            docker run -d --name elasticsearch -e ES_JAVA_OPTS="-Xms512m -Xmx512m" -p 9200:9200 -e bootstrap.memory_lock=true -e cluster.name=docker -e http.host=0.0.0.0 -e transport.host=127.0.0.1 docker.elastic.co/elasticsearch/elasticsearch:7.7.1
       - run:
           name: Test code
           command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
             cluster.name: docker-cluster
             http.host: 0.0.0.0
             transport.host: 127.0.0.1
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
         ports:
         - 9200:9200

--- a/microcosm_elasticsearch/assertions.py
+++ b/microcosm_elasticsearch/assertions.py
@@ -20,7 +20,7 @@ DEFAULT_SLEEP_SECONDS = 0.1
 
 def assert_that_eventually(func, matches, tries=DEFAULT_TRIES, sleep_seconds=DEFAULT_SLEEP_SECONDS):
     last_error = None
-    for _ in range(3):
+    for _ in range(tries):
         try:
             assert_that(func(), matches)
             break

--- a/microcosm_elasticsearch/models.py
+++ b/microcosm_elasticsearch/models.py
@@ -19,7 +19,7 @@ class Model(Document):
     updated_at = Date(required=True)
 
     # In ES6+ indices have a single mapping type
-    # To allow for polymorphic documents, we define a field holding the document type
+    # To allow for polymorphic documents, we define a custom field holding the document type.
     doctype = Keyword(required=True)
 
     def __init__(self, meta=None, **kwargs):

--- a/microcosm_elasticsearch/searching.py
+++ b/microcosm_elasticsearch/searching.py
@@ -78,6 +78,7 @@ class SearchIndex:
         """
         query = self._search(**kwargs)
         results = query.execute()
+
         return self._to_list(results)
 
     def search_with_count(self, **kwargs):
@@ -90,6 +91,7 @@ class SearchIndex:
         """
         query = self._search(**kwargs)
         results = query.execute()
+
         return self._to_list(results), query.count()
 
     def _search(self, explain=False, **kwargs):

--- a/microcosm_elasticsearch/searching.py
+++ b/microcosm_elasticsearch/searching.py
@@ -21,11 +21,6 @@ class SearchIndex:
      -  It can restrict the search to specific document types.
 
     """
-    __mapping_type_name__ = "doc"
-
-    @property
-    def mapping_type_name(self):
-        return self.__class__.__mapping_type_name__
 
     @property
     def doc_type_field(self):
@@ -46,7 +41,7 @@ class SearchIndex:
         self.index = index
         # Mapping from ES custom type field to corresponding model class
         self.doc_types = dict()
-        self.mapping = Mapping(self.mapping_type_name)
+        self.mapping = Mapping()
         if doc_type is not None:
             self.register_doc_type(doc_type)
 

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -105,7 +105,6 @@ class Store:
         self.elasticsearch_client.create(
             id=instance.id,
             index=self.index_name,
-            doc_type=self.doc_type,
             body=instance.to_dict(),
         )
         return instance

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -56,6 +56,11 @@ class Store:
         """
         yield
         self.index.flush()
+        # NB. as of ES7 a flush does not have the side-effect of refresh.
+        # Given that our use of explicit flush in code typically is done for refreshing
+        # available documents to be visible to the search engine, we also invoke refresh below.
+        # See: https://qbox.io/blog/refresh-flush-operations-elasticsearch-guide
+        self.index.refresh()
 
     def new_object_id(self):
         """

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -85,10 +85,10 @@ class TestStore:
         self.store.create(self.kevin)
         self.store.create(self.steph)
         assert_that_eventually(
-            calling(self.store.count),
+            self.store.count,
             is_(equal_to(2)),
             tries=5,
-            sleep_seconds=0.5,
+            sleep_seconds=1.0,
         )
 
     def test_delete_not_found(self):
@@ -141,7 +141,7 @@ class TestStore:
     def test_search_slow(self):
         self.store.create(self.kevin)
         assert_that_eventually(
-            calling(self.store.search),
+            self.store.search,
             contains(
                 all_of(
                     has_property("id", self.kevin.id),
@@ -150,7 +150,7 @@ class TestStore:
                 ),
             ),
             tries=5,
-            sleep_seconds=0.5,
+            sleep_seconds=1.0,
         )
 
     def test_search_order_reverse_chronological(self):

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     keywords="microcosm",
     install_requires=[
         "boto3>=1.7.33",
-        "elasticsearch>=6.3.1,<7.0.0",
-        "elasticsearch-dsl>=6.2.1,<7.0.0",
+        "elasticsearch>=7.0.0",
+        "elasticsearch-dsl>=7.0.0",
         "microcosm>=2.12.0",
         "microcosm-flask>=2.8.0",
         "microcosm-metrics>=2.1.0",


### PR DESCRIPTION
*DO NOT MERGE UNLESS YOU ARE ME - PENDING UPSTREAM CHANGES TO INFRASTRUCTURE*

See [this TD](https://globality.atlassian.net/wiki/spaces/GLOB/pages/1404798557/Tech+Design+Upgrading+our+AWS+Elasticsearch+cluster) for context.

- Bump library version deps for elasticsearch to >=7.0.0
- Remove all references to deprecated doc_type / mapping_type where appropriate