### PR TITLE
Allow overloading of store index and search_index selection ( to allow things like support for one language per index ) 

### DIFF
--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -44,10 +44,28 @@ class Store:
 
     @property
     def index_name(self):
+        # Deprecated - use get_index_name instead()
         return self.index._name
 
+    def get_index_name(self):
+        return self.index._name
+
+    def get_search_index(self, **kwargs):
+        """
+            Allows for search index to be dynamically generated
+            by those subclassing this class.
+        """
+        return self.search_index
+
+    def get_index(self, **kwargs):
+        """
+            Allows for search index to be dynamically generated
+            by those subclassing this class.
+        """
+        return self.index
+
     @contextmanager
-    def flushing(self):
+    def flushing(self, **kwargs):
         """
         Flush the current session if there's no error.
 
@@ -56,12 +74,12 @@ class Store:
 
         """
         yield
-        self.index.flush()
+        self.get_index(**kwargs).flush()
         # NB. as of ES7 a flush does not have the side-effect of refresh.
         # Given that our use of explicit flush in code typically is done for refreshing
         # available documents to be visible to the search engine, we also invoke refresh below.
         # See: https://qbox.io/blog/refresh-flush-operations-elasticsearch-guide
-        self.index.refresh()
+        self.get_index(**kwargs).refresh()
 
     def new_object_id(self):
         """
@@ -81,19 +99,19 @@ class Store:
         return int(time() * 1000)
 
     def count(self, **kwargs):
-        # delegate
-        return self.search_index.count(**kwargs)
+        search_index = self.get_search_index(**kwargs)
+        return search_index.count(**kwargs)
 
     def search(self, **kwargs):
-        # delegate
-        return self.search_index.search(**kwargs)
+        search_index = self.get_search_index(**kwargs)
+        return search_index.search(**kwargs)
 
     def search_with_count(self, **kwargs):
-        # delegate
-        return self.search_index.search_with_count(**kwargs)
+        search_index = self.get_search_index(**kwargs)
+        return search_index.search_with_count(**kwargs)
 
     @translate_elasticsearch_errors
-    def create(self, instance):
+    def create(self, instance, **kwargs):
         """
         Persist an entity into Elasticsearch.
 
@@ -110,13 +128,13 @@ class Store:
         # NB: the DSL save function will overwrite existing records; use the raw client
         self.elasticsearch_client.create(
             id=instance.id,
-            index=self.index_name,
+            index=self.get_index_name(**kwargs),
             body=instance.to_dict(),
         )
         return instance
 
     @translate_elasticsearch_errors
-    def retrieve(self, identifier):
+    def retrieve(self, identifier, **kwargs):
         """
         Retrieve a model by primary key and zero or more other criteria.
 
@@ -125,12 +143,12 @@ class Store:
         """
         return self.model_class.get(
             id=identifier,
-            index=self.index_name,
+            index=self.get_index_name(**kwargs),
             using=self.elasticsearch_client,
         )
 
     @translate_elasticsearch_errors
-    def update(self, identifier, new_instance):
+    def update(self, identifier, new_instance, **kwargs):
         """
         Update an existing model with a new one.
 
@@ -143,14 +161,14 @@ class Store:
 
         new_instance.update(
             using=self.elasticsearch_client,
-            index=self.index_name,
+            index=self.get_index_name(**kwargs),
             **new_instance.to_dict()
         )
 
         return self.retrieve(identifier)
 
     @translate_elasticsearch_errors
-    def replace(self, identifier, new_instance):
+    def replace(self, identifier, new_instance, **kwargs):
         """
         Create or update an entity.
 
@@ -171,13 +189,13 @@ class Store:
         new_instance.save(
             id=new_instance.id,
             using=self.elasticsearch_client,
-            index=self.index_name,
+            index=self.get_index_name(**kwargs),
             validate=True,
         )
         return new_instance
 
     @translate_elasticsearch_errors
-    def delete(self, identifier):
+    def delete(self, identifier, **kwargs):
         """
         Delete a model by primary key.
 
@@ -186,7 +204,7 @@ class Store:
         """
         self.model_class().delete(
             id=identifier,
-            index=self.index_name,
+            index=self.get_index_name(**kwargs),
             using=self.elasticsearch_client,
         )
         return True
@@ -201,7 +219,7 @@ class Store:
             yield actions[offset:min(offset + batch_size, num_actions)]
 
     @translate_elasticsearch_errors
-    def bulk(self, actions, batch_size):
+    def bulk(self, actions, batch_size, **kwargs):
         """
         Bulk index entities
 
@@ -216,7 +234,7 @@ class Store:
                 instance.id = self.new_object_id()
 
             instance._id = instance.id
-            instance._index = self.index_name
+            instance._index = self.get_index_name(**kwargs)
 
             record = instance.to_dict(include_meta=True)
             if op_type == "delete":
@@ -233,7 +251,7 @@ class Store:
             bulk(
                 client=self.elasticsearch_client,
                 actions=actions_batch,
-                index=self.index._name,
+                index=self.get_index(**kwargs)._name,
                 raise_on_exception=False,
                 raise_on_error=False,
             ) for actions_batch in self._batch_bulk(

--- a/microcosm_elasticsearch/store.py
+++ b/microcosm_elasticsearch/store.py
@@ -44,23 +44,23 @@ class Store:
 
     @property
     def index_name(self):
-        # Deprecated - use get_index_name instead()
+        # Deprecated - use get_index_name() instead
         return self.index._name
 
-    def get_index_name(self):
-        return self.index._name
+    def get_index_name(self, **kwargs):
+        return self.get_index(**kwargs)._name
 
     def get_search_index(self, **kwargs):
         """
-            Allows for search index to be dynamically generated
-            by those subclassing this class.
+            Allows for search index to be dynamically selected
+            by subclasses
         """
         return self.search_index
 
     def get_index(self, **kwargs):
         """
-            Allows for search index to be dynamically generated
-            by those subclassing this class.
+            Allows for index to be dynamically selected
+            by subclasses
         """
         return self.index
 
@@ -99,14 +99,17 @@ class Store:
         return int(time() * 1000)
 
     def count(self, **kwargs):
+        # delegate
         search_index = self.get_search_index(**kwargs)
         return search_index.count(**kwargs)
 
     def search(self, **kwargs):
+        # delegate
         search_index = self.get_search_index(**kwargs)
         return search_index.search(**kwargs)
 
     def search_with_count(self, **kwargs):
+        # delegate
         search_index = self.get_search_index(**kwargs)
         return search_index.search_with_count(**kwargs)
 

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -61,7 +61,7 @@ class PersonSearchIndex(SearchIndex):
                     ],
                 )
             )
-        return super(PersonSearchIndex, self)._filter(query, **kwargs)
+        return super(self)._filter(query, **kwargs)
 
 
 @binding("example_search_index")
@@ -75,13 +75,13 @@ def create_example_search_index(graph):
 @binding("person_store")
 class PersonStore(Store):
     def __init__(self, graph):
-        super(PersonStore, self).__init__(graph, graph.example_index, Person, graph.example_search_index)
+        super(self).__init__(graph, graph.example_index, Person, graph.example_search_index)
 
 
 @binding("player_store")
 class PlayerStore(Store):
     def __init__(self, graph):
-        super(PlayerStore, self).__init__(graph, graph.example_index, Player, graph.example_search_index)
+        super(self).__init__(graph, graph.example_index, Player, graph.example_search_index)
 
 
 @binding("first_attribute_search_index")
@@ -95,7 +95,7 @@ def create_first_attribute_search_index(graph):
 @binding("person_overloaded_store")
 class PersonOverloadedStore(Store):
     def __init__(self, graph):
-        super(PersonOverloadedStore, self).__init__(
+        super(self).__init__(
             graph, graph.first_attribute_index, Person, graph.first_attribute_search_index)
         self.first_attribute_index = graph.first_attribute_index
         self.first_attribute_search_index = graph.first_attribute_search_index

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -2,7 +2,7 @@
 Test fixtures.
 
 """
-from enum import Enum
+from enum import Enum, auto
 
 from elasticsearch_dsl import Keyword, Q, Text
 from microcosm.api import binding
@@ -12,6 +12,9 @@ from microcosm_elasticsearch.models import Model
 from microcosm_elasticsearch.searching import SearchIndex
 from microcosm_elasticsearch.store import Store
 
+class SelectorAttribute(Enum):
+    ONE = auto()
+    TWO = auto()
 
 class Planet(Enum):
     EARTH = "EARTH"
@@ -25,6 +28,9 @@ class Planet(Enum):
 def create_example_index(graph):
     return graph.elasticsearch_index_registry.register(version="v1")
 
+@binding("first_attribute_index")
+def create_first_index(graph):
+    return graph.elasticsearch_index_registry.register(version="v1", name="first-attribute")
 
 class Person(Model):
     first = Text(required=True)
@@ -72,3 +78,44 @@ class PersonStore(Store):
 class PlayerStore(Store):
     def __init__(self, graph):
         super(PlayerStore, self).__init__(graph, graph.example_index, Player, graph.example_search_index)
+
+
+@binding("first_attribute_search_index")
+def create_first_attribute_search_index(graph):
+    return PersonSearchIndex(
+        graph=graph,
+        index=graph.first_attribute_index
+    )
+
+@binding("person_overloaded_store")
+class PersonOverloadedStore(Store):
+    def __init__(self, graph):
+        super(PersonOverloadedStore, self).__init__(graph, graph.first_attribute_index, Person, graph.first_attribute_search_index)
+        self.first_attribute_index = graph.first_attribute_index
+        self.first_attribute_search_index = graph.first_attribute_search_index
+
+        self.second_attribute_index =  graph.elasticsearch_index_registry.register(
+            version="v1",
+            name="second-attribute"
+        )
+        self.second_attribute_search_index = SearchIndex(
+            graph=graph,
+            index=self.second_attribute_index
+        )
+
+    def get_index(self, selector_attribute: SelectorAttribute, **kwargs):
+        if(selector_attribute == SelectorAttribute.ONE):
+            return self.first_attribute_index
+        elif(selector_attribute == SelectorAttribute.TWO):
+            return self.second_attribute_index
+        else:
+            raise Exception("Index not found")
+
+
+    def get_search_index(self, selector_attribute: SelectorAttribute, **kwargs):
+        if(selector_attribute == SelectorAttribute.ONE):
+            return self.first_attribute_search_index
+        elif(selector_attribute == SelectorAttribute.TWO):
+            return self.second_attribute_search_index
+        else:
+            raise Exception("Index not found")

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -12,9 +12,11 @@ from microcosm_elasticsearch.models import Model
 from microcosm_elasticsearch.searching import SearchIndex
 from microcosm_elasticsearch.store import Store
 
+
 class SelectorAttribute(Enum):
     ONE = auto()
     TWO = auto()
+
 
 class Planet(Enum):
     EARTH = "EARTH"
@@ -28,9 +30,11 @@ class Planet(Enum):
 def create_example_index(graph):
     return graph.elasticsearch_index_registry.register(version="v1")
 
+
 @binding("first_attribute_index")
 def create_first_index(graph):
     return graph.elasticsearch_index_registry.register(version="v1", name="first-attribute")
+
 
 class Person(Model):
     first = Text(required=True)
@@ -87,14 +91,16 @@ def create_first_attribute_search_index(graph):
         index=graph.first_attribute_index
     )
 
+
 @binding("person_overloaded_store")
 class PersonOverloadedStore(Store):
     def __init__(self, graph):
-        super(PersonOverloadedStore, self).__init__(graph, graph.first_attribute_index, Person, graph.first_attribute_search_index)
+        super(PersonOverloadedStore, self).__init__(
+            graph, graph.first_attribute_index, Person, graph.first_attribute_search_index)
         self.first_attribute_index = graph.first_attribute_index
         self.first_attribute_search_index = graph.first_attribute_search_index
 
-        self.second_attribute_index =  graph.elasticsearch_index_registry.register(
+        self.second_attribute_index = graph.elasticsearch_index_registry.register(
             version="v1",
             name="second-attribute"
         )
@@ -103,19 +109,26 @@ class PersonOverloadedStore(Store):
             index=self.second_attribute_index
         )
 
-    def get_index(self, selector_attribute: SelectorAttribute, **kwargs):
-        if(selector_attribute == SelectorAttribute.ONE):
+    def get_index(
+            self,
+            selector_attribute: SelectorAttribute = SelectorAttribute.ONE,
+            **kwargs
+    ):
+        if selector_attribute == SelectorAttribute.ONE:
             return self.first_attribute_index
-        elif(selector_attribute == SelectorAttribute.TWO):
+        elif selector_attribute == SelectorAttribute.TWO:
             return self.second_attribute_index
         else:
             raise Exception("Index not found")
 
-
-    def get_search_index(self, selector_attribute: SelectorAttribute, **kwargs):
-        if(selector_attribute == SelectorAttribute.ONE):
+    def get_search_index(
+            self,
+            selector_attribute: SelectorAttribute = SelectorAttribute.ONE,
+            **kwargs
+    ):
+        if selector_attribute == SelectorAttribute.ONE:
             return self.first_attribute_search_index
-        elif(selector_attribute == SelectorAttribute.TWO):
+        elif selector_attribute == SelectorAttribute.TWO:
             return self.second_attribute_search_index
         else:
             raise Exception("Index not found")

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -61,7 +61,7 @@ class PersonSearchIndex(SearchIndex):
                     ],
                 )
             )
-        return super(self)._filter(query, **kwargs)
+        return super()._filter(query, **kwargs)
 
 
 @binding("example_search_index")
@@ -75,13 +75,13 @@ def create_example_search_index(graph):
 @binding("person_store")
 class PersonStore(Store):
     def __init__(self, graph):
-        super(self).__init__(graph, graph.example_index, Person, graph.example_search_index)
+        super().__init__(graph, graph.example_index, Person, graph.example_search_index)
 
 
 @binding("player_store")
 class PlayerStore(Store):
     def __init__(self, graph):
-        super(self).__init__(graph, graph.example_index, Player, graph.example_search_index)
+        super().__init__(graph, graph.example_index, Player, graph.example_search_index)
 
 
 @binding("first_attribute_search_index")
@@ -95,7 +95,7 @@ def create_first_attribute_search_index(graph):
 @binding("person_overloaded_store")
 class PersonOverloadedStore(Store):
     def __init__(self, graph):
-        super(self).__init__(
+        super().__init__(
             graph, graph.first_attribute_index, Person, graph.first_attribute_search_index)
         self.first_attribute_index = graph.first_attribute_index
         self.first_attribute_search_index = graph.first_attribute_search_index

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -31,7 +31,6 @@ class TestStore:
     def setup(self):
         self.graph = create_object_graph("example", testing=True)
         self.store = self.graph.person_store
-        self.overloaded_store = self.graph.person_overloaded_store
         self.graph.elasticsearch_index_registry.createall(force=True)
 
         self.kevin = Person(
@@ -42,17 +41,6 @@ class TestStore:
         self.steph = Person(
             first="Steph",
             last="Curry",
-            origin_planet=Planet.MARS,
-        )
-
-        self.person_in_one = Person(
-            first="One",
-            last="Person",
-            origin_planet=Planet.MARS,
-        )
-        self.person_in_two = Person(
-            first="Two",
-            last="Person",
             origin_planet=Planet.MARS,
         )
 
@@ -331,6 +319,19 @@ class TestOverloadedStore(TestStore):
 
     def setup(self):
         super().setup()
+        self.overloaded_store = self.graph.person_overloaded_store
+
+        self.person_in_one = Person(
+            first="One",
+            last="Person",
+            origin_planet=Planet.MARS,
+        )
+        self.person_in_two = Person(
+            first="Two",
+            last="Person",
+            origin_planet=Planet.MARS,
+        )
+
         with self.overloaded_store.flushing(selector_attribute=SelectorAttribute.ONE):
             self.overloaded_store.create(
                 self.person_in_one,

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -326,7 +326,11 @@ class TestStore:
         ))
         assert_that(result[1][0]['delete'], has_entry('result', 'not_found'))
 
-    def test_overloaded_store(self):
+
+class TestOverloadedStore(TestStore):
+
+    def setup(self):
+        super().setup()
         with self.overloaded_store.flushing(selector_attribute=SelectorAttribute.ONE):
             self.overloaded_store.create(
                 self.person_in_one,
@@ -339,6 +343,7 @@ class TestStore:
                 selector_attribute=SelectorAttribute.TWO
             )
 
+    def test_search_with_count(self):
         result, count = self.overloaded_store.search_with_count(selector_attribute=SelectorAttribute.ONE)
         assert_that(result[0], has_property("id", self.person_in_one.id))
         assert_that(count, is_(equal_to(1)))
@@ -346,3 +351,24 @@ class TestStore:
         result, count = self.overloaded_store.search_with_count(selector_attribute=SelectorAttribute.TWO)
         assert_that(result[0], has_property("id", self.person_in_two.id))
         assert_that(count, is_(equal_to(1)))
+
+    def test_search(self):
+        assert_that(
+            self.overloaded_store.search(selector_attribute=SelectorAttribute.ONE),
+            contains(
+                all_of(
+                    has_property("id", self.person_in_one.id),
+                    has_property("first", "One"),
+                ),
+            ),
+        )
+
+        assert_that(
+            self.overloaded_store.search(selector_attribute=SelectorAttribute.TWO),
+            contains(
+                all_of(
+                    has_property("id", self.person_in_two.id),
+                    has_property("first", "Two"),
+                ),
+            ),
+        )

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -31,6 +31,7 @@ class TestStore:
     def setup(self):
         self.graph = create_object_graph("example", testing=True)
         self.store = self.graph.person_store
+        self.overloaded_store = self.graph.person_overloaded_store
         self.graph.elasticsearch_index_registry.createall(force=True)
 
         self.kevin = Person(
@@ -319,7 +320,6 @@ class TestOverloadedStore(TestStore):
 
     def setup(self):
         super().setup()
-        self.overloaded_store = self.graph.person_overloaded_store
 
         self.person_in_one = Person(
             first="One",

--- a/microcosm_elasticsearch/tests/test_store.py
+++ b/microcosm_elasticsearch/tests/test_store.py
@@ -32,7 +32,6 @@ class TestStore:
         self.graph = create_object_graph("example", testing=True)
         self.store = self.graph.person_store
         self.overloaded_store = self.graph.person_overloaded_store
-
         self.graph.elasticsearch_index_registry.createall(force=True)
 
         self.kevin = Person(
@@ -186,9 +185,12 @@ class TestStore:
                 mocked.return_value = self.kevin.created_at + timedelta(seconds=1).seconds * 1000
                 self.store.create(self.steph)
 
-        result = self.store.search(offset=1, limit=1)
-        assert_that(result, contains(has_property("id", self.kevin.id)))
-
+        assert_that(
+            self.store.search(offset=1, limit=1),
+            contains(
+                has_property("id", self.kevin.id),
+            ),
+        )
         assert_that(
             self.store.search(offset=0, limit=1),
             contains(


### PR DESCRIPTION
Enabling "dynamic" switching between indices - Added a `get_` for index and the "search index".

This is to enable switching in the case that we have indices that have a logical grouping that we want to switch between. e.g. the same data in different languages - we want to be able to switch between languages.