### PR TITLE
Explicitly register document mapping

### DIFF
--- a/microcosm_elasticsearch/mapping.py
+++ b/microcosm_elasticsearch/mapping.py
@@ -1,0 +1,12 @@
+from elasticsearch_dsl import Mapping
+
+from microcosm_elasticsearch.models import Model
+
+
+def create_mapping(*model_classes: Model) -> Mapping:
+    mapping = Mapping()
+
+    for model_class in model_classes:
+        mapping.update(model_class._doc_type.mapping)
+
+    return mapping

--- a/microcosm_elasticsearch/registry.py
+++ b/microcosm_elasticsearch/registry.py
@@ -16,7 +16,7 @@ class IndexRegistry:
         self.graph = graph
         self.indexes = {}
 
-    def register(self, name=None, version=None, settings=None):
+    def register(self, name=None, version=None, settings=None, mapping=None):
         """
         Register an index locally.
 
@@ -27,6 +27,8 @@ class IndexRegistry:
          -  The "test" suffix is added for unit testing (to avoid clobbering real data)
 
         If version is provided, it will be used to create generate an alias (to the unversioned name).
+
+        Registering `mapping` on the `index` if `mapping` argument provided.
 
         """
         if version is None:
@@ -47,6 +49,9 @@ class IndexRegistry:
 
         if settings:
             index.settings(**settings)
+
+        if mapping:
+            index.mapping(mapping)
 
         if alias_name is not None:
             index.aliases(**{alias_name: {}})

--- a/microcosm_elasticsearch/searching.py
+++ b/microcosm_elasticsearch/searching.py
@@ -2,8 +2,6 @@
 Index search.
 
 """
-from elasticsearch_dsl.mapping import Mapping
-
 from microcosm_elasticsearch.errors import translate_elasticsearch_errors
 
 
@@ -41,18 +39,12 @@ class SearchIndex:
         self.index = index
         # Mapping from ES custom type field to corresponding model class
         self.doc_types = dict()
-        self.mapping = Mapping()
         if doc_type is not None:
             self.register_doc_type(doc_type)
 
     def register_doc_type(self, model_class):
         model_doctype = model_class.get_model_doctype()
         self.doc_types[model_doctype] = model_class
-        self.update_mapping(model_class)
-
-    def update_mapping(self, model_class):
-        self.mapping.update(model_class._doc_type.mapping)
-        self.index.mapping(self.mapping)
 
     @property
     def index_name(self):

--- a/microcosm_elasticsearch/tests/fixtures.py
+++ b/microcosm_elasticsearch/tests/fixtures.py
@@ -8,6 +8,7 @@ from elasticsearch_dsl import Keyword, Q, Text
 from microcosm.api import binding
 
 from microcosm_elasticsearch.fields import EnumField
+from microcosm_elasticsearch.mapping import create_mapping
 from microcosm_elasticsearch.models import Model
 from microcosm_elasticsearch.searching import SearchIndex
 from microcosm_elasticsearch.store import Store
@@ -28,12 +29,19 @@ class Planet(Enum):
 
 @binding("example_index")
 def create_example_index(graph):
-    return graph.elasticsearch_index_registry.register(version="v1")
+    return graph.elasticsearch_index_registry.register(
+        version="v1",
+        mapping=create_mapping(Person),
+    )
 
 
 @binding("first_attribute_index")
 def create_first_index(graph):
-    return graph.elasticsearch_index_registry.register(version="v1", name="first-attribute")
+    return graph.elasticsearch_index_registry.register(
+        version="v1",
+        name="first-attribute",
+        mapping=create_mapping(Person),
+    )
 
 
 class Person(Model):
@@ -102,7 +110,8 @@ class PersonOverloadedStore(Store):
 
         self.second_attribute_index = graph.elasticsearch_index_registry.register(
             version="v1",
-            name="second-attribute"
+            name="second-attribute",
+            mapping=create_mapping(Person),
         )
         self.second_attribute_search_index = SearchIndex(
             graph=graph,


### PR DESCRIPTION
**BREAKING CHANGE** - major release to follow.

Auto-registration of document mappings is convenient, but problematic in more complex scenarios. Dropping the concept in favor of explicit registration of the _mapping_ object. A client of the library is to provide the desired `mapping` at the moment of _index_ registration - it is the only time when a library is mutating the `mapping` of an _index_.