### PR TITLE
Context Changes for DEVOPS-3866

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,14 +218,14 @@ workflows:
   build-and-release:
     jobs:
       - checkout:
-          context: 
+          context:
           - Globality-Common
           filters:
             # run for all branches and tags
             tags:
               only: /.*/
       - build_docker:
-          context: 
+          context:
           - Globality-Common
           requires:
             - checkout
@@ -234,7 +234,7 @@ workflows:
             tags:
               only: /.*/
       - lint:
-          context: 
+          context:
           - Globality-Common
           requires:
             - build_docker
@@ -243,7 +243,7 @@ workflows:
             tags:
               only: /.*/
       - test:
-          context: 
+          context:
           - Globality-Common
           requires:
             - build_docker
@@ -252,14 +252,14 @@ workflows:
             tags:
               only: /.*/
       - deploy_jfrog_rc:
-          context: 
+          context:
           - Globality-Common
           requires:
             - test
             - lint
             - typehinting
       - typehinting:
-          context: 
+          context:
           - Globality-Common
           requires:
             - build_docker
@@ -268,8 +268,9 @@ workflows:
             tags:
               only: /.*/
       - publish_library:
-          context: 
+          context:
           - Globality-Common
+          - Python-Context
           requires:
             - test
             - lint


### PR DESCRIPTION
Removed Python-Context from the global scope and kept scope in the right place, as this context should not be available to all services. \nScoped to specific Python-Context as per the Jira ticket DEVOPS-3866 (more details on Jira